### PR TITLE
fixed footer lookup on mails

### DIFF
--- a/resources/mail/footer.php
+++ b/resources/mail/footer.php
@@ -1,6 +1,6 @@
 <footer style="text-align: center; font-size: 8pt; color: #aaaaaa; border-top: 1px solid #dddddd; padding-top: 10px;">
     <span>You are receiving this email because you have an account 
-        on the <a target='_blank' href='<?php echo $BRANDING["site"]["url"]; ?>'>Unity Cluster</a> 
+        on the <a target='_blank' href='<?php echo $this->MSG_LINKREF; ?>'>Unity Cluster</a> 
         at UMass Amherst. If you would like to stop receiving these emails, 
         you may request to close your account by replying to this email.</span>
 </footer>


### PR DESCRIPTION
The footer was throwing an error for users in emails, because an old `$BRANDING` array was left in. This is tested and working.