### PR TITLE
Made emailing admins for PI requests optional

### DIFF
--- a/defaults/config.ini.default
+++ b/defaults/config.ini.default
@@ -92,6 +92,7 @@ sender = "sender-email@unitywebportal.test"  ; The "from" email for all messages
 sender_name = "Unity Sender"
 pi_approve = "piapproval@unitywebportal.test"  ; Only PI approval messages will go to this email
 pi_approve_name = "Unity PI Approval"
+send_pimesg_to_admins = false
 
 [webhook] ; webhook to send messages to admins
 url = "https://hooks.slack.com/services/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"

--- a/resources/init.php
+++ b/resources/init.php
@@ -106,6 +106,7 @@ if (!is_null($SSO)) {
 
     $_SESSION["user_exists"] = $USER->exists();
     $_SESSION["is_pi"] = $USER->isPI();
+    $SEND_PIMESG_TO_ADMINS = $CONFIG["mail"]["send_pimesg_to_admins"];
 
     $SQL->addLog(
         $OPERATOR->getUID(),

--- a/resources/lib/UnityGroup.php
+++ b/resources/lib/UnityGroup.php
@@ -71,7 +71,7 @@ class UnityGroup
     // Portal-facing methods, these are the methods called by scripts in webroot
     //
 
-    public function requestGroup($send_mail = true)
+    public function requestGroup($send_mail_to_admins, $send_mail = true)
     {
         // check for edge cases...
         if ($this->exists()) {
@@ -97,16 +97,18 @@ class UnityGroup
                 )
             );
 
-            $this->MAILER->sendMail(
-                "admin",
-                "group_request_admin",
-                array(
-                    "user" => $this->getOwner()->getUID(),
-                    "org" => $this->getOwner()->getOrg(),
-                    "name" => $this->getOwner()->getFullname(),
-                    "email" => $this->getOwner()->getMail()
-                )
-            );
+            if ($send_mail_to_admins) {
+                $this->MAILER->sendMail(
+                    "admin",
+                    "group_request_admin",
+                    array(
+                        "user" => $this->getOwner()->getUID(),
+                        "org" => $this->getOwner()->getOrg(),
+                        "name" => $this->getOwner()->getFullname(),
+                        "email" => $this->getOwner()->getMail()
+                    )
+                );
+            }
 
             $this->MAILER->sendMail(
                 "pi_approve",

--- a/webroot/panel/account.php
+++ b/webroot/panel/account.php
@@ -66,7 +66,7 @@ if ($_SERVER['REQUEST_METHOD'] == "POST") {
         case "pi_request":
             if (!$USER->isPI()) {
                 if (!$SQL->requestExists($USER->getUID())) {
-                    $USER->getPIGroup()->requestGroup();
+                    $USER->getPIGroup()->requestGroup($SEND_PIMESG_TO_ADMINS);
                 }
             }
             break;

--- a/webroot/panel/new_account.php
+++ b/webroot/panel/new_account.php
@@ -32,7 +32,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     if (count($errors) == 0) {
         if ($_POST["new_user_sel"] == "pi") {
             // requesting a PI account
-            $USER->getPIGroup()->requestGroup();
+            $USER->getPIGroup()->requestGroup($SEND_PIMESG_TO_ADMINS);
         } elseif ($_POST["new_user_sel"] == "not_pi") {
             $form_group->newUserRequest($USER);
         }


### PR DESCRIPTION
- Added a boolean config variable `send_pimesg_to_admins` to set whether PI request mails go to admins or not.
- #63 