### PR TITLE
added option for account deletion requests

### DIFF
--- a/resources/lib/UnityGroup.php
+++ b/resources/lib/UnityGroup.php
@@ -78,6 +78,11 @@ class UnityGroup
             return;
         }
 
+        // check if account deletion request already exists
+        if ($this->SQL->accDeletionRequestExists($this->getOwner()->getUID())) {
+            return;
+        }
+
         $this->SQL->addRequest($this->getOwner()->getUID());
 
         if ($send_mail) {
@@ -349,6 +354,11 @@ class UnityGroup
         }
 
         if ($this->requestExists($new_user)) {
+            return;
+        }
+
+        // check if account deletion request already exists
+        if ($this->SQL->accDeletionRequestExists($new_user->getUID())) {
             return;
         }
 

--- a/resources/lib/UnitySQL.php
+++ b/resources/lib/UnitySQL.php
@@ -12,6 +12,7 @@ class UnitySQL
     private const TABLE_PAGES = "pages";
     private const TABLE_EVENTS = "events";
     private const TABLE_AUDIT_LOG = "audit_log";
+    private const TABLE_ACCOUNT_DELETION_REQUESTS = "account_deletion_requests";
 
     private const REQUEST_ADMIN = "admin";
 
@@ -251,5 +252,27 @@ class UnitySQL
         $stmt->bindParam(":recipient", $recipient);
 
         $stmt->execute();
+    }
+
+    public function addAccountDeletionRequest($uid)
+    {
+        $stmt = $this->conn->prepare(
+            "INSERT INTO " . self::TABLE_ACCOUNT_DELETION_REQUESTS . " (uid) VALUE (:uid)"
+        );
+        $stmt->bindParam(":uid", $uid);
+
+        $stmt->execute();
+    }
+
+    public function accDeletionRequestExists($uid)
+    {
+        $stmt = $this->conn->prepare(
+            "SELECT * FROM " . self::TABLE_ACCOUNT_DELETION_REQUESTS . " WHERE uid=:uid"
+        );
+        $stmt->bindParam(":uid", $uid);
+
+        $stmt->execute();
+
+        return count($stmt->fetchAll()) > 0;
     }
 }

--- a/resources/lib/UnityUser.php
+++ b/resources/lib/UnityUser.php
@@ -671,5 +671,4 @@ class UnityUser
     {
         return $this->SQL->accDeletionRequestExists($this->getUID());
     }
-
 }

--- a/resources/lib/UnityUser.php
+++ b/resources/lib/UnityUser.php
@@ -644,4 +644,32 @@ class UnityUser
 
         return $out;
     }
+
+    /**
+     * Sends an email to admins about account deletion request and also adds it to a table in the database
+     */
+    public function requestAccountDeletion()
+    {
+        $this->SQL->addAccountDeletionRequest($this->getUID());
+        $this->MAILER->sendMail(
+            "admin",
+            "account_deletion_request_admin",
+            array(
+                "user" => $this->getUID(),
+                "name" => $this->getFullname(),
+                "email" => $this->getMail()
+            )
+        );
+    }
+
+    /**
+     * Checks if the user has requested account deletion
+     *
+     * @return boolean true if account deletion has been requested, false if not
+     */
+    public function hasRequestedAccountDeletion()
+    {
+        return $this->SQL->accDeletionRequestExists($this->getUID());
+    }
+
 }

--- a/resources/mail/account_deletion_request_admin.php
+++ b/resources/mail/account_deletion_request_admin.php
@@ -1,0 +1,17 @@
+<?php
+
+// This template is sent to admins when a new group is requested
+$this->Subject = "Account Deletion Request";
+?>
+
+<p>Hello,</p>
+
+<p>A user has requested deletion of their account. User details are below:</p>
+
+<p>
+    <strong>Username</strong> <?php echo $data["user"]; ?>
+    <br>
+    <strong>Name</strong> <?php echo $data["name"]; ?>
+    <br>
+    <strong>Email</strong> <?php echo $data["email"]; ?>
+</p>

--- a/tools/docker-dev/sql/bootstrap.sql
+++ b/tools/docker-dev/sql/bootstrap.sql
@@ -108,6 +108,20 @@ CREATE TABLE `audit_log` (
 
 -- --------------------------------------------------------
 
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `account_deletion_requests`
+--
+
+CREATE TABLE `account_deletion_requests` (
+  `id` int(11) NOT NULL,
+  `timestamp` timestamp NOT NULL DEFAULT current_timestamp(),
+  `uid` varchar(1000) NOT NULL,
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- --------------------------------------------------------
+
 --
 -- Indexes for dumped tables
 --
@@ -149,6 +163,12 @@ ALTER TABLE `audit_log`
   ADD PRIMARY KEY (`id`);
 
 --
+-- Indexes for table `audit_log`
+--
+ALTER TABLE `account_deletion_requests`
+  ADD PRIMARY KEY (`id`);
+
+--
 -- AUTO_INCREMENT for dumped tables
 --
 
@@ -186,6 +206,14 @@ ALTER TABLE `sso_log`
 -- AUTO_INCREMENT for table `audit_log`
 --
 ALTER TABLE `audit_log`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+COMMIT;
+
+--
+--
+-- AUTO_INCREMENT for table `account_deletion_requests`
+--
+ALTER TABLE `account_deletion_requests`
   MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
 COMMIT;
 

--- a/webroot/admin/user-mgmt.php
+++ b/webroot/admin/user-mgmt.php
@@ -43,7 +43,11 @@ include $LOC_HEADER;
     });
 
     foreach ($users as $user) {
-        echo "<tr>";
+        if ($user->hasRequestedAccountDeletion()) {
+            echo "<tr style='color:grey; font-style: italic'>"; // grey out and italicize users who have requested account deletion
+        } else {
+            echo "<tr>";
+        }
         echo "<td>" . $user->getFirstname() . " " . $user->getLastname() . "</td>";
         echo "<td>" . $user->getUID() . "</td>";
         echo "<td>" . $user->getOrg() . "</td>";

--- a/webroot/admin/user-mgmt.php
+++ b/webroot/admin/user-mgmt.php
@@ -44,7 +44,7 @@ include $LOC_HEADER;
 
     foreach ($users as $user) {
         if ($user->hasRequestedAccountDeletion()) {
-            echo "<tr style='color:grey; font-style: italic'>"; // grey out and italicize users who have requested account deletion
+            echo "<tr style='color:grey; font-style: italic'>";
         } else {
             echo "<tr>";
         }

--- a/webroot/panel/account.php
+++ b/webroot/panel/account.php
@@ -118,7 +118,10 @@ if (!$isPI) {
         onsubmit='return confirm(\"Are you sure you want to request a PI account?\")'>
         <input type='hidden' name='form_type' value='pi_request'>";
         echo "<input type='submit' value='Request PI Account' disabled>";
-        echo "<label style='margin-left: 10px'>You cannot request PI Account while you have requested account deletion.</label>";
+        echo
+        "<label style='margin-left: 10px'>
+            You cannot request PI Account while you have requested account deletion.
+        </label>";
         echo "</form>";
     } else {
         echo

--- a/webroot/panel/account.php
+++ b/webroot/panel/account.php
@@ -71,7 +71,10 @@ if ($_SERVER['REQUEST_METHOD'] == "POST") {
             }
             break;
         case "account_deletion_request":
-            if (!$SQL->accDeletionRequestExists($USER->getUID())) {
+            $hasGroups = count($USER->getGroups()) > 0;
+            if ($hasGroups) {
+                die();
+            } else if (!$SQL->accDeletionRequestExists($USER->getUID())) {
                 $USER->requestAccountDeletion();
             }
             break;

--- a/webroot/panel/account.php
+++ b/webroot/panel/account.php
@@ -74,7 +74,9 @@ if ($_SERVER['REQUEST_METHOD'] == "POST") {
             $hasGroups = count($USER->getGroups()) > 0;
             if ($hasGroups) {
                 die();
-            } else if (!$SQL->accDeletionRequestExists($USER->getUID())) {
+                break;
+            }
+            if (!$SQL->accDeletionRequestExists($USER->getUID())) {
                 $USER->requestAccountDeletion();
             }
             break;

--- a/webroot/panel/account.php
+++ b/webroot/panel/account.php
@@ -70,6 +70,19 @@ if ($_SERVER['REQUEST_METHOD'] == "POST") {
                 }
             }
             break;
+        case "account_deletion_request":
+            $hasGroups = count($USER->getGroups()) > 0;
+            if (!$hasGroups) {
+                if (!$SQL->accDeletionRequestExists($USER->getUID())) {
+                    $USER->requestAccountDeletion();
+                }
+            } else {
+                echo "<script type='text/javascript'>
+                alert('You cannot delete your account while you are a member of a PI group.');
+                </script>
+                ";
+            }
+            break;
     }
 }
 ?>
@@ -193,6 +206,28 @@ for ($i = 0; $sshPubKeys != null && $i < count($sshPubKeys); $i++) {  // loop th
     <input type='submit' value='Set Login Shell'>
 
 </form>
+
+<hr>
+
+<h5>Account Deletion</h5>
+<?php
+
+    echo
+        "<form action='' method='POST' id='accDel' 
+        onsubmit='return confirm(\"Are you sure you want to request an account deletion?\")'>
+        <input type='hidden' name='form_type' value='account_deletion_request'>";
+        if ($SQL->accDeletionRequestExists($USER->getUID())) {
+            echo "<input type='submit' value='Request Account Deletion' disabled>";
+            echo "<label style='margin-left: 10px'>Your request has been submitted and is currently pending</label>";
+        } else {
+            echo "<input type='submit' value='Request Account Deletion'>";
+        }
+        echo "</form>";
+
+?>
+
+<hr>
+
 
 <script>
     $("button.btnAddKey").click(function() {

--- a/webroot/panel/account.php
+++ b/webroot/panel/account.php
@@ -71,16 +71,8 @@ if ($_SERVER['REQUEST_METHOD'] == "POST") {
             }
             break;
         case "account_deletion_request":
-            $hasGroups = count($USER->getGroups()) > 0;
-            if (!$hasGroups) {
-                if (!$SQL->accDeletionRequestExists($USER->getUID())) {
-                    $USER->requestAccountDeletion();
-                }
-            } else {
-                echo "<script type='text/javascript'>
-                alert('You cannot delete your account while you are a member of a PI group.');
-                </script>
-                ";
+            if (!$SQL->accDeletionRequestExists($USER->getUID())) {
+                $USER->requestAccountDeletion();
             }
             break;
     }
@@ -120,17 +112,27 @@ if ($isPI) {
 }
 
 if (!$isPI) {
-    echo
-    "<form action='' method='POST' id='piReq' 
-    onsubmit='return confirm(\"Are you sure you want to request a PI account?\")'>
-    <input type='hidden' name='form_type' value='pi_request'>";
-    if ($SQL->requestExists($USER->getUID())) {
+    if ($SQL->accDeletionRequestExists($USER->getUID())) {
+        echo
+        "<form action='' method='POST' id='piReq' 
+        onsubmit='return confirm(\"Are you sure you want to request a PI account?\")'>
+        <input type='hidden' name='form_type' value='pi_request'>";
         echo "<input type='submit' value='Request PI Account' disabled>";
-        echo "<label style='margin-left: 10px'>Your request has been submitted and is currently pending</label>";
+        echo "<label style='margin-left: 10px'>You cannot request PI Account while you have requested account deletion.</label>";
+        echo "</form>";
     } else {
-        echo "<input type='submit' value='Request PI Account'>";
+        echo
+        "<form action='' method='POST' id='piReq' 
+        onsubmit='return confirm(\"Are you sure you want to request a PI account?\")'>
+        <input type='hidden' name='form_type' value='pi_request'>";
+        if ($SQL->requestExists($USER->getUID())) {
+            echo "<input type='submit' value='Request PI Account' disabled>";
+            echo "<label style='margin-left: 10px'>Your request has been submitted and is currently pending</label>";
+        } else {
+            echo "<input type='submit' value='Request PI Account'>";
+        }
+        echo "</form>";
     }
-    echo "</form>";
 }
 ?>
 
@@ -211,18 +213,23 @@ for ($i = 0; $sshPubKeys != null && $i < count($sshPubKeys); $i++) {  // loop th
 
 <h5>Account Deletion</h5>
 <?php
+$hasGroups = count($USER->getGroups()) > 0;
 
-echo
-"<form action='' method='POST' id='accDel' 
-onsubmit='return confirm(\"Are you sure you want to request an account deletion?\")'>
-<input type='hidden' name='form_type' value='account_deletion_request'>";
-if ($SQL->accDeletionRequestExists($USER->getUID())) {
-    echo "<input type='submit' value='Request Account Deletion' disabled>";
-    echo "<label style='margin-left: 10px'>Your request has been submitted and is currently pending</label>";
+if ($hasGroups) {
+    echo "<p>You cannot request to delete your account while you are in a PI group.</p>";
 } else {
-    echo "<input type='submit' value='Request Account Deletion'>";
+    echo
+    "<form action='' method='POST' id='accDel' 
+    onsubmit='return confirm(\"Are you sure you want to request an account deletion?\")'>
+    <input type='hidden' name='form_type' value='account_deletion_request'>";
+    if ($SQL->accDeletionRequestExists($USER->getUID())) {
+        echo "<input type='submit' value='Request Account Deletion' disabled>";
+        echo "<label style='margin-left: 10px'>Your request has been submitted and is currently pending</label>";
+    } else {
+        echo "<input type='submit' value='Request Account Deletion'>";
+    }
+    echo "</form>";
 }
-echo "</form>";
 
 ?>
 

--- a/webroot/panel/account.php
+++ b/webroot/panel/account.php
@@ -212,17 +212,17 @@ for ($i = 0; $sshPubKeys != null && $i < count($sshPubKeys); $i++) {  // loop th
 <h5>Account Deletion</h5>
 <?php
 
-    echo
-        "<form action='' method='POST' id='accDel' 
-        onsubmit='return confirm(\"Are you sure you want to request an account deletion?\")'>
-        <input type='hidden' name='form_type' value='account_deletion_request'>";
-        if ($SQL->accDeletionRequestExists($USER->getUID())) {
-            echo "<input type='submit' value='Request Account Deletion' disabled>";
-            echo "<label style='margin-left: 10px'>Your request has been submitted and is currently pending</label>";
-        } else {
-            echo "<input type='submit' value='Request Account Deletion'>";
-        }
-        echo "</form>";
+echo
+"<form action='' method='POST' id='accDel' 
+onsubmit='return confirm(\"Are you sure you want to request an account deletion?\")'>
+<input type='hidden' name='form_type' value='account_deletion_request'>";
+if ($SQL->accDeletionRequestExists($USER->getUID())) {
+    echo "<input type='submit' value='Request Account Deletion' disabled>";
+    echo "<label style='margin-left: 10px'>Your request has been submitted and is currently pending</label>";
+} else {
+    echo "<input type='submit' value='Request Account Deletion'>";
+}
+echo "</form>";
 
 ?>
 

--- a/webroot/panel/groups.php
+++ b/webroot/panel/groups.php
@@ -125,7 +125,14 @@ foreach ($groups as $group) {
 echo "</table>";
 ?>
 
-<button type="button" class="plusBtn btnAddPI">&#43;</button>
+<?php
+if ($SQL->accDeletionRequestExists($USER->getUID())) {
+    echo "<button type='button' class='plusBtn btnAddPI' disabled>&#43;</button>";
+    echo "<label>You cannot join a PI while you have requested account deletion.</label>";
+} else {
+    echo "<button type='button' class='plusBtn btnAddPI'>&#43;</button>";
+}
+?>
 
 <style>
     div.modalContent {


### PR DESCRIPTION
- Gave user option to request account deletion (only if user is not in any PI groups)
![Screenshot 2023-06-02 at 9 48 12 AM](https://github.com/UnityHPC/unity-web-portal/assets/58443068/3e31c785-22ab-4b5f-98a4-4279de0b5bd9)
- Adds them to a new SQL table - `account_deletion_requests`
- Sends email to admins
![Screenshot 2023-06-02 at 9 48 27 AM](https://github.com/UnityHPC/unity-web-portal/assets/58443068/bbff36b9-f57f-49bb-a1ec-80694cb990d2)
- Updates user management for admins (graying and italicizing the users who have requested account deletion)
![Screenshot 2023-06-02 at 9 48 47 AM](https://github.com/UnityHPC/unity-web-portal/assets/58443068/55e7f951-71c6-4a19-a81c-55d4df765f10)
- #43 

