### PR TITLE
stored max id values in sitevars table

### DIFF
--- a/resources/lib/UnityGroup.php
+++ b/resources/lib/UnityGroup.php
@@ -482,7 +482,7 @@ class UnityGroup
         $ldapPiGroupEntry = $this->getLDAPPiGroup();
 
         if (!$ldapPiGroupEntry->exists()) {
-            $nextGID = $this->LDAP->getNextPiGIDNumber();
+            $nextGID = $this->LDAP->getNextPiGIDNumber($this->SQL);
 
             $ldapPiGroupEntry->setAttribute("objectclass", UnityLDAP::POSIX_GROUP_CLASS);
             $ldapPiGroupEntry->setAttribute("gidnumber", strval($nextGID));

--- a/resources/lib/UnityLDAP.php
+++ b/resources/lib/UnityLDAP.php
@@ -120,9 +120,9 @@ class UnityLDAP extends ldapConn
         $max_uid = $UnitySQL->getSiteVar('MAX_UID');
         $new_uid = $max_uid + 1;
 
-       while ($this->UIDNumInUse($new_uid)) {
-           $new_uid++;
-       }
+        while ($this->UIDNumInUse($new_uid)) {
+            $new_uid++;
+        }
 
         $UnitySQL->updateSiteVar('MAX_UID', $new_uid);
 
@@ -134,12 +134,8 @@ class UnityLDAP extends ldapConn
         $max_pigid = $UnitySQL->getSiteVar('MAX_PIGID');
         $new_pigid = $max_pigid + 1;
 
-        $pi_groups = $this->pi_groupOU->getChildrenArray(true);
-
-        foreach ($pi_groups as $group) {
-            if ($group["gidnumber"][0] == $new_pigid) {
-                $new_pigid++;
-            }
+        while ($this->PiGIDNumInUse($new_pigid)) {
+            $new_pigid++;
         }
 
         $UnitySQL->updateSiteVar('MAX_PIGID', $new_pigid);
@@ -152,12 +148,8 @@ class UnityLDAP extends ldapConn
         $max_gid = $UnitySQL->getSiteVar('MAX_GID');
         $new_gid = $max_gid + 1;
 
-        $groups = $this->org_groupOU->getChildrenArray(true);
-
-        foreach ($groups as $group) {
-            if ($group["gidnumber"][0] == $new_gid) {
-                $new_gid++;
-            }
+        while ($this->GIDNumInUse($new_gid)) {
+            $new_gid++;
         }
 
         $UnitySQL->updateSiteVar('MAX_GID', $new_gid);
@@ -177,11 +169,23 @@ class UnityLDAP extends ldapConn
         return false;
     }
 
+    private function PiGIDNumInUse($id)
+    {
+        $pi_groups = $this->pi_groupOU->getChildrenArray(true);
+        foreach ($pi_groups as $pi_group) {
+            if ($pi_group["gidnumber"][0] == $id) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private function GIDNumInUse($id)
     {
-        $users = $this->groupOU->getChildrenArray(true);
-        foreach ($users as $user) {
-            if ($user["gidnumber"][0] == $id) {
+        $groups = $this->groupOU->getChildrenArray(true);
+        foreach ($groups as $group) {
+            if ($group["gidnumber"][0] == $id) {
                 return true;
             }
         }

--- a/resources/lib/UnityLDAP.php
+++ b/resources/lib/UnityLDAP.php
@@ -120,13 +120,9 @@ class UnityLDAP extends ldapConn
         $max_uid = $UnitySQL->getSiteVar('MAX_UID');
         $new_uid = $max_uid + 1;
 
-        $is_already_in_use = $this->UIDNumInUse($new_uid);
-
-        if ($is_already_in_use) {
-            while ($this->UIDNumInUse($new_uid)) {
-                $new_uid++;
-            }
-        }
+       while ($this->UIDNumInUse($new_uid)) {
+           $new_uid++;
+       }
 
         $UnitySQL->updateSiteVar('MAX_UID', $new_uid);
 

--- a/resources/lib/UnityLDAP.php
+++ b/resources/lib/UnityLDAP.php
@@ -120,6 +120,14 @@ class UnityLDAP extends ldapConn
         $max_uid = $UnitySQL->getSiteVar('MAX_UID');
         $new_uid = $max_uid + 1;
 
+        $is_already_in_use = $this->UIDNumInUse($new_uid);
+
+        if ($is_already_in_use) {
+            while ($this->UIDNumInUse($new_uid)) {
+                $new_uid++;
+            }
+        }
+
         $UnitySQL->updateSiteVar('MAX_UID', $new_uid);
 
         return $new_uid;
@@ -130,6 +138,14 @@ class UnityLDAP extends ldapConn
         $max_pigid = $UnitySQL->getSiteVar('MAX_PIGID');
         $new_pigid = $max_pigid + 1;
 
+        $pi_groups = $this->pi_groupOU->getChildrenArray(true);
+
+        foreach ($pi_groups as $group) {
+            if ($group["gidnumber"][0] == $new_pigid) {
+                $new_pigid++;
+            }
+        }
+
         $UnitySQL->updateSiteVar('MAX_PIGID', $new_pigid);
 
         return $new_pigid;
@@ -139,6 +155,14 @@ class UnityLDAP extends ldapConn
     {
         $max_gid = $UnitySQL->getSiteVar('MAX_GID');
         $new_gid = $max_gid + 1;
+
+        $groups = $this->org_groupOU->getChildrenArray(true);
+
+        foreach ($groups as $group) {
+            if ($group["gidnumber"][0] == $new_gid) {
+                $new_gid++;
+            }
+        }
 
         $UnitySQL->updateSiteVar('MAX_GID', $new_gid);
 

--- a/resources/lib/UnityLDAP.php
+++ b/resources/lib/UnityLDAP.php
@@ -115,67 +115,34 @@ class UnityLDAP extends ldapConn
   //
   // ID Number selection functions
   //
-    public function getNextUIDNumber()
+    public function getNextUIDNumber($UnitySQL)
     {
-        $users = $this->userOU->getChildrenArray(true);
+        $max_uid = $UnitySQL->getSiteVar('MAX_UID');
+        $new_uid = $max_uid + 1;
 
-      // This could become inefficient with more users
-        usort($users, function ($a, $b) {
-            return $a["uidnumber"] <=> $b["uidnumber"];
-        });
+        $UnitySQL->updateSiteVar('MAX_UID', $new_uid);
 
-        $id = self::ID_MAP[0];
-        foreach ($users as $acc) {
-            if ($id == $acc["uidnumber"][0]) {
-                $id++;
-            } else {
-                if (!$this->GIDNumInUse($id)) {
-                    break;
-                }
-            }
-        }
-
-        return $id;
+        return $new_uid;
     }
 
-    public function getNextPiGIDNumber()
+    public function getNextPiGIDNumber($UnitySQL)
     {
-        $groups = $this->pi_groupOU->getChildrenArray(true);
+        $max_pigid = $UnitySQL->getSiteVar('MAX_PIGID');
+        $new_pigid = $max_pigid + 1;
 
-        usort($groups, function ($a, $b) {
-            return $a["gidnumber"] <=> $b["gidnumber"];
-        });
+        $UnitySQL->updateSiteVar('MAX_PIGID', $new_pigid);
 
-        $id = self::PI_ID_MAP[0];
-        foreach ($groups as $acc) {
-            if ($id == $acc["gidnumber"][0]) {
-                $id++;
-            } else {
-                break;
-            }
-        }
-
-        return $id;
+        return $new_pigid;
     }
 
-    public function getNextOrgGIDNumber()
+    public function getNextOrgGIDNumber($UnitySQL)
     {
-        $groups = $this->org_groupOU->getChildrenArray(true);
+        $max_gid = $UnitySQL->getSiteVar('MAX_GID');
+        $new_gid = $max_gid + 1;
 
-        usort($groups, function ($a, $b) {
-            return $a["gidnumber"] <=> $b["gidnumber"];
-        });
+        $UnitySQL->updateSiteVar('MAX_GID', $new_gid);
 
-        $id = self::ORG_ID_MAP[0];
-        foreach ($groups as $acc) {
-            if ($id == $acc["gidnumber"][0]) {
-                $id++;
-            } else {
-                break;
-            }
-        }
-
-        return $id;
+        return $new_gid;
     }
 
     private function UIDNumInUse($id)
@@ -202,7 +169,7 @@ class UnityLDAP extends ldapConn
         return false;
     }
 
-    public function getUnassignedID($uid)
+    public function getUnassignedID($uid, $UnitySQL)
     {
         $netid = strtok($uid, "_");  // extract netid
       // scrape all files in custom folder
@@ -226,7 +193,7 @@ class UnityLDAP extends ldapConn
         }
 
       // didn't find anything from existing mappings, use next available
-        $next_uid = $this->getNextUIDNumber();
+        $next_uid = $this->getNextUIDNumber($UnitySQL);
 
         return $next_uid;
     }

--- a/resources/lib/UnityLDAP.php
+++ b/resources/lib/UnityLDAP.php
@@ -134,7 +134,7 @@ class UnityLDAP extends ldapConn
         $max_pigid = $UnitySQL->getSiteVar('MAX_PIGID');
         $new_pigid = $max_pigid + 1;
 
-        while ($this->PiGIDNumInUse($new_pigid)) {
+        while ($this->PIGIDNumInUse($new_pigid)) {
             $new_pigid++;
         }
 
@@ -169,7 +169,7 @@ class UnityLDAP extends ldapConn
         return false;
     }
 
-    private function PiGIDNumInUse($id)
+    private function PIGIDNumInUse($id)
     {
         $pi_groups = $this->pi_groupOU->getChildrenArray(true);
         foreach ($pi_groups as $pi_group) {

--- a/resources/lib/UnityOrg.php
+++ b/resources/lib/UnityOrg.php
@@ -30,7 +30,7 @@ class UnityOrg
         $org_group = $this->getLDAPOrgGroup();
 
         if (!$org_group->exists()) {
-            $nextGID = $this->LDAP->getNextOrgGIDNumber();
+            $nextGID = $this->LDAP->getNextOrgGIDNumber($this->SQL);
 
             $org_group->setAttribute("objectclass", UnityLDAP::POSIX_GROUP_CLASS);
             $org_group->setAttribute("gidnumber", strval($nextGID));

--- a/resources/lib/UnitySQL.php
+++ b/resources/lib/UnitySQL.php
@@ -13,6 +13,7 @@ class UnitySQL
     private const TABLE_EVENTS = "events";
     private const TABLE_AUDIT_LOG = "audit_log";
     private const TABLE_ACCOUNT_DELETION_REQUESTS = "account_deletion_requests";
+    private const TABLE_SITEVARS = "sitevars";
 
     private const REQUEST_ADMIN = "admin";
 
@@ -274,5 +275,28 @@ class UnitySQL
         $stmt->execute();
 
         return count($stmt->fetchAll()) > 0;
+    }
+
+    public function getSiteVar($name)
+    {
+        $stmt = $this->conn->prepare(
+            "SELECT * FROM " . self::TABLE_SITEVARS . " WHERE name=:name"
+        );
+        $stmt->bindParam(":name", $name);
+
+        $stmt->execute();
+
+        return $stmt->fetchAll()[0]['value'];
+    }
+
+    public function updateSiteVar($name, $value)
+    {
+        $stmt = $this->conn->prepare(
+            "UPDATE " . self::TABLE_SITEVARS . " SET value=:value WHERE name=:name"
+        );
+        $stmt->bindParam(":name", $name);
+        $stmt->bindParam(":value", $value);
+
+        $stmt->execute();
     }
 }

--- a/resources/lib/UnityUser.php
+++ b/resources/lib/UnityUser.php
@@ -53,7 +53,7 @@ class UnityUser
         // Create LDAP group
         //
         $ldapGroupEntry = $this->getLDAPGroup();
-        $id = $this->LDAP->getUnassignedID($this->getUID());
+        $id = $this->LDAP->getUnassignedID($this->getUID(), $this->SQL);
 
         if (!$ldapGroupEntry->exists()) {
             $ldapGroupEntry->setAttribute("objectclass", UnityLDAP::POSIX_GROUP_CLASS);

--- a/tools/docker-dev/sql/bootstrap.sql
+++ b/tools/docker-dev/sql/bootstrap.sql
@@ -122,6 +122,20 @@ CREATE TABLE `account_deletion_requests` (
 
 -- --------------------------------------------------------
 
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `sitevars`
+--
+
+CREATE TABLE `sitevars` (
+  `id` int(11) NOT NULL,
+  `name` varchar(1000) NOT NULL,
+  `value` varchar(1000) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- --------------------------------------------------------
+
 --
 -- Indexes for dumped tables
 --
@@ -166,6 +180,12 @@ ALTER TABLE `audit_log`
 -- Indexes for table `audit_log`
 --
 ALTER TABLE `account_deletion_requests`
+  ADD PRIMARY KEY (`id`);
+
+--
+-- Indexes for table `sitevars`
+--
+ALTER TABLE `sitevars`
   ADD PRIMARY KEY (`id`);
 
 --
@@ -215,6 +235,13 @@ COMMIT;
 --
 ALTER TABLE `account_deletion_requests`
   MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+COMMIT;
+
+--
+-- AUTO_INCREMENT for table `sitevars`
+--
+ALTER TABLE `sitevars`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT, AUTO_INCREMENT=2;
 COMMIT;
 
 /*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;


### PR DESCRIPTION
- Made new table `sitevars` (Structure: `id`, `name`, `value`)
- Initially maximum uid, gid, pigid need to be stored in the table with names as `MAX_UID`, `MAX_GID`, `MAX_PIGID`.
- Then, whenever a new user, group, or pi group is created, the id assigned is an increment of the maximum value by 1.
- #76 