### PR TITLE
delete "events"

### DIFF
--- a/resources/lib/UnitySQL.php
+++ b/resources/lib/UnitySQL.php
@@ -10,7 +10,6 @@ class UnitySQL
     private const TABLE_NOTICES = "notices";
     private const TABLE_SSOLOG = "sso_log";
     private const TABLE_PAGES = "pages";
-    private const TABLE_EVENTS = "events";
     private const TABLE_AUDIT_LOG = "audit_log";
     private const TABLE_ACCOUNT_DELETION_REQUESTS = "account_deletion_requests";
     private const TABLE_SITEVARS = "sitevars";
@@ -232,18 +231,6 @@ class UnitySQL
             "edited_page",
             $operator
         );
-    }
-
-    public function addEvent($operator, $action, $entity)
-    {
-        $stmt = $this->conn->prepare(
-            "INSERT INTO " . self::TABLE_EVENTS . " (operator, action, entity) VALUE (:operator, :action, :entity)"
-        );
-        $stmt->bindParam(":operator", $operator);
-        $stmt->bindParam(":action", $action);
-        $stmt->bindParam(":entity", $entity);
-
-        $stmt->execute();
     }
 
     // audit log table methods

--- a/tools/docker-dev/sql/bootstrap.sql
+++ b/tools/docker-dev/sql/bootstrap.sql
@@ -36,14 +36,6 @@ CREATE TABLE `audit_log` (
   `recipient` varchar(1000) NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
-CREATE TABLE `events` (
-  `id` int(11) NOT NULL,
-  `operator` varchar(300) NOT NULL,
-  `action` varchar(300) NOT NULL,
-  `entity` varchar(300) NOT NULL,
-  `timestamp` timestamp NOT NULL DEFAULT current_timestamp()
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
-
 CREATE TABLE `groupJoinRequests` (
   `id` int(11) NOT NULL,
   `group_name` varchar(1000) NOT NULL,
@@ -137,9 +129,6 @@ ALTER TABLE `account_deletion_requests`
 ALTER TABLE `audit_log`
   ADD PRIMARY KEY (`id`);
 
-ALTER TABLE `events`
-  ADD PRIMARY KEY (`id`);
-
 ALTER TABLE `groupJoinRequests`
   ADD PRIMARY KEY (`id`);
 
@@ -174,9 +163,6 @@ ALTER TABLE `account_deletion_requests`
   MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
 
 ALTER TABLE `audit_log`
-  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
-
-ALTER TABLE `events`
   MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
 
 ALTER TABLE `groupJoinRequests`


### PR DESCRIPTION
function has never been called in any version of the web portal:
```
for h in $(git rev-list HEAD); do git checkout $h &>/dev/null; echo $h; rg 'addEvent\('; done
```