### PR TITLE
improve ssh key validation

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -7,5 +7,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: php-actions/composer@v6
-    - uses: php-actions/phpunit@v3
+    - name: setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: "8.3"
+        # php extensions also listed in tools/docker-dev/web/Dockerfile
+        extensions: curl,mysql,ldap,pdo,redis,cli
+        tools: composer:v2
+    - name: Install dependencies
+      run: composer install --prefer-dist --no-progress
+    - name: Run PHPUnit tests
+      run: vendor/bin/phpunit

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -17,4 +17,4 @@ jobs:
     - name: Install dependencies
       run: composer install --prefer-dist --no-progress
     - name: Run PHPUnit tests
-      run: vendor/bin/phpunit --debug
+      run: vendor/bin/phpunit

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -12,9 +12,9 @@ jobs:
       with:
         php-version: "8.3"
         # php extensions also listed in tools/docker-dev/web/Dockerfile
-        extensions: curl,mysql,ldap,pdo,redis,cli
+        extensions: curl,mysql,ldap,pdo,redis
         tools: composer:v2
     - name: Install dependencies
       run: composer install --prefer-dist --no-progress
     - name: Run PHPUnit tests
-      run: vendor/bin/phpunit
+      run: vendor/bin/phpunit --debug

--- a/composer.json
+++ b/composer.json
@@ -4,5 +4,8 @@
         "phpseclib/phpseclib": "3.0.43",
         "phpmailer/phpmailer": "6.6.4",
         "hakasapl/phpopenldaper": "1.0.5"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^12.1"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,6 @@
         "hakasapl/phpopenldaper": "1.0.5"
     },
     "require-dev": {
-        "phpunit/phpunit": "^12.1"
+        "phpunit/phpunit": "<12.1"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,9 +1,9 @@
+  <!-- restrictWarnings="true" -->
 <phpunit
   bootstrap="test/unit/bootstrap.php"
   failOnWarning="true"
   failOnDeprecation="true"
   failOnNotice="true"
-  <!-- restrictWarnings="true" -->
 >
   <testsuites>
     <testsuite name="unit">

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,7 +3,7 @@
   failOnWarning="true"
   failOnDeprecation="true"
   failOnNotice="true"
-  restrictWarnings="true"
+  <!-- restrictWarnings="true" -->
 >
   <testsuites>
     <testsuite name="unit">

--- a/resources/lib/UnitySite.php
+++ b/resources/lib/UnitySite.php
@@ -50,7 +50,7 @@ class UnitySite
     public static function testValidSSHKey($key_str)
     {
         $key_str = trim($key_str);
-        if ($key_str == ""){
+        if ($key_str == "") {
             return false;
         }
         // PHP warning when key_str is digits: Attempt to read property "keys" on int
@@ -58,7 +58,7 @@ class UnitySite
             return false;
         }
         // PHP warning when key_str is JSON: Undefined property: stdClass::$keys
-        if (!is_null(@json_decode($key_str))){
+        if (!is_null(@json_decode($key_str))) {
             return false;
         }
         try {

--- a/resources/lib/UnitySite.php
+++ b/resources/lib/UnitySite.php
@@ -49,6 +49,18 @@ class UnitySite
 
     public static function testValidSSHKey($key_str)
     {
+        $key_str = trim($key_str);
+        if ($key_str == ""){
+            return false;
+        }
+        // PHP warning when key_str is digits: Attempt to read property "keys" on int
+        if (preg_match("/^[0-9]+$/", $key_str)) {
+            return false;
+        }
+        // PHP warning when key_str is JSON: Undefined property: stdClass::$keys
+        if (!is_null(@json_decode($key_str))){
+            return false;
+        }
         try {
             PublicKeyLoader::load($key_str);
             return true;

--- a/test/unit/AjaxSshValidateTest.php
+++ b/test/unit/AjaxSshValidateTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace UnityWebPortal\lib;
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class AjaxSshValidateTest extends TestCase
+{
+    public static function providerTestSshValidate()
+    {
+        // sanity check only, see UnitySiteTest for more comprehensive test cases
+        return [
+            [false, "foobar"],
+            // phpcs:disable
+            [true, "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIB+XqO25MUB9x/pS04I3JQ7rMGboWyGXh0GUzkOrTi7a"],
+            // phpcs:enable
+        ];
+    }
+
+    #[DataProvider("providerTestSshValidate")]
+    public function testSshValidate(bool $is_valid, string $pubkey)
+    {
+        $_SERVER["REQUEST_METHOD"] = "POST";
+        $_POST["key"] = $pubkey;
+        ob_start();
+        include __DIR__ . "/../../webroot/js/ajax/ssh_validate.php";
+        $output = ob_get_clean();
+        if ($is_valid) {
+            $this->assertEquals("true", $output);
+        } else {
+            $this->assertEquals("false", $output);
+        }
+    }
+}

--- a/test/unit/AjaxSshValidateTest.php
+++ b/test/unit/AjaxSshValidateTest.php
@@ -24,11 +24,8 @@ class AjaxSshValidateTest extends TestCase
         $_SERVER["REQUEST_METHOD"] = "POST";
         $_POST["key"] = $pubkey;
         ob_start();
-        try {
-            include __DIR__ . "/../../webroot/js/ajax/ssh_validate.php";
-        } finally {
-            $output = ob_get_clean();
-        }
+        include __DIR__ . "/../../webroot/js/ajax/ssh_validate.php";
+        $output = ob_get_clean();
         if ($is_valid) {
             $this->assertEquals("true", $output);
         } else {

--- a/test/unit/AjaxSshValidateTest.php
+++ b/test/unit/AjaxSshValidateTest.php
@@ -24,8 +24,11 @@ class AjaxSshValidateTest extends TestCase
         $_SERVER["REQUEST_METHOD"] = "POST";
         $_POST["key"] = $pubkey;
         ob_start();
-        include __DIR__ . "/../../webroot/js/ajax/ssh_validate.php";
-        $output = ob_get_clean();
+        try {
+            include __DIR__ . "/../../webroot/js/ajax/ssh_validate.php";
+        } finally {
+            $output = ob_get_clean();
+        }
         if ($is_valid) {
             $this->assertEquals("true", $output);
         } else {

--- a/tools/docker-dev/web/Dockerfile
+++ b/tools/docker-dev/web/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu:20.04
 
 # Web Server Setup
 ARG DEBIAN_FRONTEND=noninteractive
+# php extensions also listed in .github/workflows/phpunit.yml
 RUN apt-get update && apt-get install -y \
     apache2 \
     apache2-utils \

--- a/webroot/js/ajax/ssh_validate.php
+++ b/webroot/js/ajax/ssh_validate.php
@@ -2,11 +2,7 @@
 
 require "../../../resources/autoload.php";
 
+use UnityWebPortal\lib\UnitySite;
 use phpseclib3\Crypt\PublicKeyLoader;
 
-try {
-    PublicKeyLoader::load($_POST['key'], $password = false);
-    echo "true";
-} catch (Exception $e) {
-    echo "false";
-}
+echo (UnitySite::testValidSSHKey($_POST["key"]) ? "true" : "false");

--- a/webroot/js/ajax/ssh_validate.php
+++ b/webroot/js/ajax/ssh_validate.php
@@ -1,5 +1,6 @@
 <?php
-require __DIR__ . "/../../../resources/autoload.php";
+
+require __DIR__ . "/../../../resources/lib/UnitySite.php";
 use UnityWebPortal\lib\UnitySite;
 
 echo UnitySite::testValidSSHKey($_POST["key"]) ? "true" : "false";

--- a/webroot/js/ajax/ssh_validate.php
+++ b/webroot/js/ajax/ssh_validate.php
@@ -1,8 +1,5 @@
 <?php
-
-require "../../../resources/autoload.php";
-
+require __DIR__ . "/../../../resources/autoload.php";
 use UnityWebPortal\lib\UnitySite;
-use phpseclib3\Crypt\PublicKeyLoader;
 
-echo (UnitySite::testValidSSHKey($_POST["key"]) ? "true" : "false");
+echo UnitySite::testValidSSHKey($_POST["key"]) ? "true" : "false";

--- a/webroot/js/ajax/ssh_validate.php
+++ b/webroot/js/ajax/ssh_validate.php
@@ -1,6 +1,6 @@
 <?php
 
-require __DIR__ . "/../../../resources/lib/UnitySite.php";
+require_once __DIR__ . "/../../../resources/lib/UnitySite.php";
 use UnityWebPortal\lib\UnitySite;
 
 echo UnitySite::testValidSSHKey($_POST["key"]) ? "true" : "false";


### PR DESCRIPTION
https://github.com/UnityHPC/unity-web-portal/pull/179 added failing tests, this PR makes those tests pass. Also tests the ajax ssh key validation.

I had to remove the `autoload.php` from this file since it tries to open external connections. I think that's fine since this file is so trivial, but would like a second opinion. Along with the external connections it also sets up `$SSO`, `$USER`, `$OPERATOR`, `$_SESSION` keys `SSO` `is_admin` `user_exists` `is_pi`