### PR TITLE
Remove custom shell

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,11 @@ When submitting pull requests, the pull request should be made to the version yo
 
 This code base is currently using PHP version 7.4. All files are required to be linted with PSR-12 standard. This repository will automatically check PRs for linting compliance.
 
+Whenever frontend JS limits the possible values of a user input, PHP must do the same!
+There's nothing stopping a user from making custom HTTP POST requests.
+This can be done in `webroot/panel/*.php` while parsing headers, or preferrably in `resources/lib/*.php`.
+For example, both frontend JS and in the `UnityUser` class make sure that a login shell contains only ASCII characters.
+
 ## Development Environment
 
 ### Setting up your Environment

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,10 +10,10 @@ When submitting pull requests, the pull request should be made to the version yo
 
 This code base is currently using PHP version 7.4. All files are required to be linted with PSR-12 standard. This repository will automatically check PRs for linting compliance.
 
-Whenever frontend JS limits the possible values of a user input, PHP must do the same!
+Whenever frontend JS limits the possible values of a user input, PHP must also do the same, and tests must be written.
 There's nothing stopping a user from making custom HTTP POST requests.
 This can be done in `webroot/panel/*.php` while parsing headers, or preferrably in `resources/lib/*.php`.
-For example, both frontend JS and in the `UnityUser` class make sure that a login shell contains only ASCII characters.
+For example, both frontend JS and in the `UnityUser` class make sure that a login shell contains only ASCII characters, and this is tested in `test/functional/LoginShellSetTest.php`.
 
 ## Development Environment
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,11 +10,6 @@ When submitting pull requests, the pull request should be made to the version yo
 
 This code base is currently using PHP version 7.4. All files are required to be linted with PSR-12 standard. This repository will automatically check PRs for linting compliance.
 
-Whenever frontend JS limits the possible values of a user input, PHP must also do the same, and tests must be written.
-There's nothing stopping a user from making custom HTTP POST requests.
-This can be done in `webroot/panel/*.php` while parsing headers, or preferrably in `resources/lib/*.php`.
-For example, both frontend JS and in the `UnityUser` class make sure that a login shell contains only ASCII characters, and this is tested in `test/functional/LoginShellSetTest.php`.
-
 ## Development Environment
 
 ### Setting up your Environment

--- a/defaults/config.ini.default
+++ b/defaults/config.ini.default
@@ -75,6 +75,7 @@ title[] = "Test Medium Footer"
 [loginshell]  ; Login shells that show up as options in the account settings page
 shell[] = "/bin/bash"
 shell[] = "/bin/zsh"
+shell[] = "/bin/tcsh"
 
 [menuitems]  ; menu items, add a label and link for each
 labels[] = "Global Menuitem 1"

--- a/resources/lib/UnityUser.php
+++ b/resources/lib/UnityUser.php
@@ -450,6 +450,9 @@ class UnityUser
         if (!mb_check_encoding($shell, 'ASCII')) {
             throw new Exception("non ascii characters are not allowed in a login shell!");
         }
+        if ($shell != trim($shell)) {
+            throw new Exception("leading/trailing whitespace is not allowed in a login shell!");
+        }
         $ldapUser = $this->getLDAPUser();
         if ($ldapUser->exists()) {
             $ldapUser->setAttribute("loginshell", $shell);

--- a/resources/lib/UnityUser.php
+++ b/resources/lib/UnityUser.php
@@ -453,6 +453,9 @@ class UnityUser
         if ($shell != trim($shell)) {
             throw new Exception("leading/trailing whitespace is not allowed in a login shell!");
         }
+        if (empty($shell)) {
+            throw new Exception("login shell must not be empty!");
+        }
         $ldapUser = $this->getLDAPUser();
         if ($ldapUser->exists()) {
             $ldapUser->setAttribute("loginshell", $shell);

--- a/resources/lib/UnityUser.php
+++ b/resources/lib/UnityUser.php
@@ -446,8 +446,10 @@ class UnityUser
      */
     public function setLoginShell($shell, $operator = null, $send_mail = true)
     {
-        // FIXME throw error if shell is not ascii
         // ldap schema syntax is "IA5 String (1.3.6.1.4.1.1466.115.121.1.26)"
+        if (!mb_check_encoding($shell, 'ASCII')) {
+            throw new Exception("non ascii characters are not allowed in a login shell!");
+        }
         $ldapUser = $this->getLDAPUser();
         if ($ldapUser->exists()) {
             $ldapUser->setAttribute("loginshell", $shell);

--- a/test/functional/LoginShellSetTest.php
+++ b/test/functional/LoginShellSetTest.php
@@ -38,21 +38,7 @@ class LoginShellSetTest extends TestCase
     }
 
     #[DataProvider("getShells")]
-    public function testSetLoginShellCustom(string $shell): void
-    {
-        global $USER;
-        if (!$this->isShellValid($shell)) {
-            $this->expectException(Exception::class);
-        }
-        post(
-            __DIR__ . "/../../webroot/panel/account.php",
-            ["form_type" => "loginshell", "shellSelect" => "Custom", "shell" => $shell]
-        );
-        $this->assertEquals($shell, $USER->getLoginShell());
-    }
-
-    #[DataProvider("getShells")]
-    public function testSetLoginShellSelect(string $shell): void
+    public function testSetLoginShell(string $shell): void
     {
         global $USER;
         if (!$this->isShellValid($shell)) {

--- a/test/functional/LoginShellSetTest.php
+++ b/test/functional/LoginShellSetTest.php
@@ -36,6 +36,9 @@ class LoginShellSetTest extends TestCase
         if (!mb_check_encoding($shell, 'ASCII')) {
             $this->expectException("Exception");
         }
+        if ($shell != trim($shell)) {
+            $this->expectException("Exception");
+        }
         // FIXME shell is not validated
         post(
             __DIR__ . "/../../webroot/panel/account.php",

--- a/test/functional/LoginShellSetTest.php
+++ b/test/functional/LoginShellSetTest.php
@@ -28,19 +28,22 @@ class LoginShellSetTest extends TestCase
         // phpcs:enable
     }
 
+    private function isShellValid(string $shell)
+    {
+        return (
+            (mb_check_encoding($shell, 'ASCII')) &&
+            ($shell == trim($shell)) &&
+            (!empty($shell))
+        );
+    }
+
     #[DataProvider("getShells")]
     public function testSetLoginShellCustom(string $shell): void
     {
         global $USER;
-        // FIXME add check to avoid warning from ldap_modify
-        if (
-            (!mb_check_encoding($shell, 'ASCII')) ||
-            ($shell != trim($shell)) ||
-            (empty($shell))
-        ) {
-            $this->expectException("Exception");
+        if (!$this->isShellValid($shell)) {
+            $this->expectException(Exception::class);
         }
-        // FIXME shell is not validated
         post(
             __DIR__ . "/../../webroot/panel/account.php",
             ["form_type" => "loginshell", "shellSelect" => "Custom", "shell" => $shell]
@@ -52,11 +55,9 @@ class LoginShellSetTest extends TestCase
     public function testSetLoginShellSelect(string $shell): void
     {
         global $USER;
-        // FIXME add check to avoid warning from ldap_modify
-        if (!mb_check_encoding($shell, 'ASCII')) {
+        if (!$this->isShellValid($shell)) {
             $this->expectException("Exception");
         }
-        // FIXME shell is not validated
         post(
             __DIR__ . "/../../webroot/panel/account.php",
             ["form_type" => "loginshell", "shellSelect" => $shell]

--- a/test/functional/LoginShellSetTest.php
+++ b/test/functional/LoginShellSetTest.php
@@ -33,10 +33,11 @@ class LoginShellSetTest extends TestCase
     {
         global $USER;
         // FIXME add check to avoid warning from ldap_modify
-        if (!mb_check_encoding($shell, 'ASCII')) {
-            $this->expectException("Exception");
-        }
-        if ($shell != trim($shell)) {
+        if (
+            (!mb_check_encoding($shell, 'ASCII')) ||
+            ($shell != trim($shell)) ||
+            (empty($shell))
+        ) {
             $this->expectException("Exception");
         }
         // FIXME shell is not validated

--- a/webroot/panel/account.php
+++ b/webroot/panel/account.php
@@ -257,7 +257,6 @@ if ($hasGroups) {
 
 <hr>
 
-
 <script>
     const sitePrefix = '<?php echo $CONFIG["site"]["prefix"]; ?>';
     const ldapLoginShell = '<?php echo $USER->getLoginShell(); ?>';
@@ -289,6 +288,57 @@ if ($hasGroups) {
     $("#loginSelector").change(showOrHideCustomLoginBox);
     showOrHideCustomLoginBox();
 
+    function getNewLoginShell() {
+        var loginSelectorVal = $("#loginSelector").val();
+        if (loginSelectorVal != "Custom") {
+            return loginSelectorVal;
+        }
+        return $("#customLoginBox").val();
+    }
+
+    function isLoginShellValid(x) {
+        if (x.trim().length === 0) {
+            return false;
+        }
+        // only ascii characters allowed
+        if (!(/^[\x00-\x7F]*$/.test(x))) {
+            return false;
+        }
+        return true;
+    }
+
+    function enableOrDisableCustomLoginBoxHighlight() {
+        if (
+            ($("#customLoginSelectorOption").prop("selected") == true) &&
+            !isLoginShellValid($("#customLoginBox").val())
+        ) {
+            $("#customLoginBox").css("box-shadow", "0 0 0 0.3rem rgba(220, 53, 69, 0.25)");
+        } else {
+            $("#customLoginBox").css("box-shadow", "none");
+        }
+    }
+    $("#customLoginBox").on("input", enableOrDisableCustomLoginBoxHighlight);
+    $("#loginSelector").change(enableOrDisableCustomLoginBoxHighlight);
+    enableOrDisableCustomLoginBoxHighlight();
+
+    function enableOrDisableSubmitLoginShell() {
+        var newLoginShell = getNewLoginShell();
+        if (!isLoginShellValid(newLoginShell)) {
+            $("#submitLoginShell").prop("disabled", true);
+            $("#submitLoginShell").prop("title", "Invalid Login Shell");
+            return;
+        }
+        if (newLoginShell == ldapLoginShell) {
+            $("#submitLoginShell").prop("disabled", true);
+            $("#submitLoginShell").prop("title", "Login Shell Unchanged");
+            return;
+        }
+        $("#submitLoginShell").prop("disabled", false);
+        $("#submitLoginShell").prop("title", "Submit Login Shell");
+    }
+    $("#customLoginBox").on("input", enableOrDisableSubmitLoginShell);
+    $("#loginSelector").change(enableOrDisableSubmitLoginShell);
+    enableOrDisableSubmitLoginShell()
 </script>
 
 <style>

--- a/webroot/panel/account.php
+++ b/webroot/panel/account.php
@@ -69,11 +69,7 @@ if ($_SERVER['REQUEST_METHOD'] == "POST") {
             $USER->setSSHKeys($keys, $OPERATOR);  // Update user keys
             break;
         case "loginshell":
-            if ($_POST["shellSelect"] == "Custom") {
-                $USER->setLoginShell($_POST["shell"], $OPERATOR);
-            } else {
-                $USER->setLoginShell($_POST["shellSelect"], $OPERATOR);
-            }
+            $USER->setLoginShell($_POST["shellSelect"], $OPERATOR);
             break;
         case "pi_request":
             if (!$USER->isPI()) {
@@ -210,19 +206,8 @@ for ($i = 0; $sshPubKeys != null && $i < count($sshPubKeys); $i++) {  // loop th
 foreach ($CONFIG["loginshell"]["shell"] as $shell) {
     echo "<option>$shell</option>";
 }
-echo "<option id='customLoginSelectorOption'>Custom</option>";
 ?>
 </select>
-<?php
-echo "
-    <input
-        id='customLoginBox'
-        type='text'
-        placeholder='Enter login shell path (ie. /bin/bash)'
-        name='shell'
-    />
-";
-?>
 <br>
 <input id='submitLoginShell' type='submit' value='Set Login Shell' />
 <label id='labelSubmitLoginShell'> <!-- value set by JS --> </label>
@@ -266,83 +251,19 @@ if ($hasGroups) {
         openModal("Add New Key", `${sitePrefix}/panel/modal/new_key.php`);
     });
 
-    var defaultShellSelected = false;
     $("#loginSelector option").each(function(i, e) {
         if ($(this).val() == ldapLoginShell) {
             $(this).prop("selected", true);
-            defaultShellSelected = true;
         }
     });
-    if (!defaultShellSelected) {
-        $("#customLoginBox").val(ldapLoginShell);
-        $("#customLoginSelectorOption").prop("selected", true);
-    }
-
-    function showOrHideCustomLoginBox() {
-        var customBox = $("#customLoginBox");
-        if($("#loginSelector").val() == "Custom") {
-            customBox.show();
-        } else {
-            customBox.hide();
-        }
-    }
-    $("#loginSelector").change(showOrHideCustomLoginBox);
-    showOrHideCustomLoginBox();
-
-    function getNewLoginShell() {
-        var loginSelectorVal = $("#loginSelector").val();
-        if (loginSelectorVal != "Custom") {
-            return loginSelectorVal;
-        }
-        return $("#customLoginBox").val();
-    }
-
-    function isLoginShellValid(x) {
-        if (/^\s|\s$/.test(x)) {
-            return [false, "must not have leading or trailing whitespace"];
-        }
-        if (x.length === 0) {
-            return [false, "must not be empty"];
-        }
-        if (!(/^[\x00-\x7F]*$/.test(x))) {
-            return [false, "must only contain ASCII characters"];
-        }
-        return [true, ""];
-    }
-
-    function enableOrDisableCustomLoginBoxHighlight() {
-        if (
-            ($("#customLoginSelectorOption").prop("selected") == true) &&
-            !isLoginShellValid($("#customLoginBox").val())
-        ) {
-            $("#customLoginBox").css("box-shadow", "0 0 0 0.3rem rgba(220, 53, 69, 0.25)");
-        } else {
-            $("#customLoginBox").css("box-shadow", "none");
-        }
-    }
-    $("#customLoginBox").on("input", enableOrDisableCustomLoginBoxHighlight);
-    $("#loginSelector").change(enableOrDisableCustomLoginBoxHighlight);
-    enableOrDisableCustomLoginBoxHighlight();
 
     function enableOrDisableSubmitLoginShell() {
-        var newLoginShell = getNewLoginShell();
-        isValidArr = isLoginShellValid(newLoginShell);
-        isValid = isValidArr[0];
-        isValidReason = isValidArr[1];
-        if (!isValid) {
+        if ($("#loginSelector").val() == ldapLoginShell) {
             $("#submitLoginShell").prop("disabled", true);
-            $("#labelSubmitLoginShell").text(`(invalid login shell: ${isValidReason})`);
-            return;
+        } else {
+            $("#submitLoginShell").prop("disabled", false);
         }
-        if (newLoginShell == ldapLoginShell) {
-            $("#submitLoginShell").prop("disabled", true);
-            $("#labelSubmitLoginShell").text("(no change)");
-            return;
-        }
-        $("#submitLoginShell").prop("disabled", false);
-        $("#labelSubmitLoginShell").text("");
     }
-    $("#customLoginBox").on("input", enableOrDisableSubmitLoginShell);
     $("#loginSelector").change(enableOrDisableSubmitLoginShell);
     enableOrDisableSubmitLoginShell()
 </script>

--- a/webroot/panel/account.php
+++ b/webroot/panel/account.php
@@ -304,7 +304,6 @@ if ($hasGroups) {
         if (x.length === 0) {
             return [false, "must not be empty"];
         }
-        // only ascii characters allowed
         if (!(/^[\x00-\x7F]*$/.test(x))) {
             return [false, "must only contain ASCII characters"];
         }

--- a/webroot/panel/account.php
+++ b/webroot/panel/account.php
@@ -225,6 +225,7 @@ echo "
 ?>
 <br>
 <input id='submitLoginShell' type='submit' value='Set Login Shell' />
+<label id='labelSubmitLoginShell'> <!-- value set by JS --> </label>
 </form>
 <hr>
 
@@ -297,14 +298,17 @@ if ($hasGroups) {
     }
 
     function isLoginShellValid(x) {
-        if (x.trim().length === 0) {
-            return false;
+        if (/^\s|\s$/.test(x)) {
+            return [false, "must not have leading or trailing whitespace"];
+        }
+        if (x.length === 0) {
+            return [false, "must not be empty"];
         }
         // only ascii characters allowed
         if (!(/^[\x00-\x7F]*$/.test(x))) {
-            return false;
+            return [false, "must only contain ASCII characters"];
         }
-        return true;
+        return [true, ""];
     }
 
     function enableOrDisableCustomLoginBoxHighlight() {
@@ -323,18 +327,21 @@ if ($hasGroups) {
 
     function enableOrDisableSubmitLoginShell() {
         var newLoginShell = getNewLoginShell();
-        if (!isLoginShellValid(newLoginShell)) {
+        isValidArr = isLoginShellValid(newLoginShell);
+        isValid = isValidArr[0];
+        isValidReason = isValidArr[1];
+        if (!isValid) {
             $("#submitLoginShell").prop("disabled", true);
-            $("#submitLoginShell").prop("title", "Invalid Login Shell");
+            $("#labelSubmitLoginShell").text(`(invalid login shell: ${isValidReason})`);
             return;
         }
         if (newLoginShell == ldapLoginShell) {
             $("#submitLoginShell").prop("disabled", true);
-            $("#submitLoginShell").prop("title", "Login Shell Unchanged");
+            $("#labelSubmitLoginShell").text("(no change)");
             return;
         }
         $("#submitLoginShell").prop("disabled", false);
-        $("#submitLoginShell").prop("title", "Submit Login Shell");
+        $("#labelSubmitLoginShell").text("");
     }
     $("#customLoginBox").on("input", enableOrDisableSubmitLoginShell);
     $("#loginSelector").change(enableOrDisableSubmitLoginShell);


### PR DESCRIPTION
this is the fun alternative to https://github.com/UnityHPC/unity-web-portal/pull/200

Fixes a WSOD when a user tries to set their login shell with non ascii characters. Also avoids the LDAP warnings generated in testing: https://github.com/UnityHPC/unity-web-portal/actions/runs/14648366156/job/41108067187

It also grays out the submit button when there's no change.

https://github.com/user-attachments/assets/f076c765-f578-4191-9835-63ff704c3b7f