### PR TITLE
prettify login shell selector

### DIFF
--- a/webroot/css/global.css
+++ b/webroot/css/global.css
@@ -28,6 +28,12 @@ code {
     line-height: 22pt;
 }
 
+.code {
+    background: var(--light_panel_background);
+    line-height: 22pt;
+    font-family: monospace
+}
+
 a {
     color: var(--accent);
     text-decoration: none;
@@ -186,8 +192,7 @@ input[type=radio] {
 select {
     border: 1px solid var(--light_borders);
     background: white;
-    padding: 5px;
-    width: 100%;
+    padding: 5px 10px 5px 20px;
     max-width: 300px;
     border-radius: 5px;
 }

--- a/webroot/panel/account.php
+++ b/webroot/panel/account.php
@@ -202,7 +202,7 @@ for ($i = 0; $sshPubKeys != null && $i < count($sshPubKeys); $i++) {  // loop th
 
 <form action="" method="POST">
 <input type="hidden" name="form_type" value="loginshell" />
-<select id="loginSelector" name="shellSelect">
+<select id="loginSelector" class="code" name="shellSelect">
 <?php
 foreach ($CONFIG["loginshell"]["shell"] as $shell) {
     echo "<option>$shell</option>";


### PR DESCRIPTION
* added a `.code` CSS class so that any element can be code
* removed `width: 100%` from `<select>` and `<input type=select>`
* added extra padding (more left than right) to `<select>` and `<input type=select>`
    * more left than right because the right has the downward arrow symbol
* modified the account settings login shell select to have the `code` class

before: 

https://github.com/user-attachments/assets/33817c19-7dd0-4f5e-b7e2-e85ac06cb092

after:

https://github.com/user-attachments/assets/937b734d-bb4c-4ebc-b950-03ce03c21801