### PR TITLE
remove disband PI

### DIFF
--- a/resources/lib/UnityGroup.php
+++ b/resources/lib/UnityGroup.php
@@ -198,47 +198,47 @@ class UnityGroup
         }
     }
 
-    /**
-     * This method will delete the group, either by admin action or PI action
-     */
-    public function removeGroup($send_mail = true)
-    {
-        // remove any pending requests
-        // this will silently fail if the request doesn't exist (which is what we want)
-        $this->SQL->removeRequests($this->pi_uid);
+    // /**
+    //  * This method will delete the group, either by admin action or PI action
+    //  */
+    // public function removeGroup($send_mail = true)
+    // {
+    //     // remove any pending requests
+    //     // this will silently fail if the request doesn't exist (which is what we want)
+    //     $this->SQL->removeRequests($this->pi_uid);
 
-        // we don't need to do anything extra if the group is already deleted
-        if (!$this->exists()) {
-            return;
-        }
+    //     // we don't need to do anything extra if the group is already deleted
+    //     if (!$this->exists()) {
+    //         return;
+    //     }
 
-        // first, we must record the users in the group currently
-        $users = $this->getGroupMembers();
+    //     // first, we must record the users in the group currently
+    //     $users = $this->getGroupMembers();
 
-        // now we delete the ldap entry
-        $ldapPiGroupEntry = $this->getLDAPPiGroup();
-        if ($ldapPiGroupEntry->exists()) {
-            if (!$ldapPiGroupEntry->delete()) {
-                throw new Exception("Unable to delete PI ldap group");
-            }
+    //     // now we delete the ldap entry
+    //     $ldapPiGroupEntry = $this->getLDAPPiGroup();
+    //     if ($ldapPiGroupEntry->exists()) {
+    //         if (!$ldapPiGroupEntry->delete()) {
+    //             throw new Exception("Unable to delete PI ldap group");
+    //         }
 
-            $this->REDIS->removeCacheArray("sorted_groups", "", $this->getPIUID());
-            foreach ($users as $user) {
-                $this->REDIS->removeCacheArray($user->getUID(), "groups", $this->getPIUID());
-            }
-        }
+    //         $this->REDIS->removeCacheArray("sorted_groups", "", $this->getPIUID());
+    //         foreach ($users as $user) {
+    //             $this->REDIS->removeCacheArray($user->getUID(), "groups", $this->getPIUID());
+    //         }
+    //     }
 
-        // send email to every user of the now deleted PI group
-        if ($send_mail) {
-            foreach ($users as $user) {
-                $this->MAILER->sendMail(
-                    $user->getMail(),
-                    "group_disband",
-                    array("group_name" => $this->pi_uid)
-                );
-            }
-        }
-    }
+    //     // send email to every user of the now deleted PI group
+    //     if ($send_mail) {
+    //         foreach ($users as $user) {
+    //             $this->MAILER->sendMail(
+    //                 $user->getMail(),
+    //                 "group_disband",
+    //                 array("group_name" => $this->pi_uid)
+    //             );
+    //         }
+    //     }
+    // }
 
     /**
      * This method is executed when a user is approved to join the group (either by admin or the group owner)

--- a/webroot/admin/pi-mgmt.php
+++ b/webroot/admin/pi-mgmt.php
@@ -27,11 +27,6 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
             }
 
             break;
-        case "remGroup":
-            $remGroup = new UnityGroup($_POST["pi"], $LDAP, $SQL, $MAILER, $REDIS, $WEBHOOK);
-            $remGroup->removeGroup();
-
-            break;
         case "reqChild":
             $parent_group = new UnityGroup($_POST["pi"], $LDAP, $SQL, $MAILER, $REDIS, $WEBHOOK);
             if ($_POST["action"] == "Approve") {

--- a/webroot/admin/pi-mgmt.php
+++ b/webroot/admin/pi-mgmt.php
@@ -123,15 +123,6 @@ include $LOC_HEADER;
         " " . $pi_user->getLastname() . "</td>";
         echo "<td>" . $pi_group->getPIUID() . "</td>";
         echo "<td><a href='mailto:" . $pi_user->getMail() . "'>" . $pi_user->getMail() . "</a></td>";
-        echo "<td>";
-        echo
-        "<form action='' method='POST'
-    onsubmit='return confirm(\"Are you sure you want to remove " . $pi_group->getPIUID() . "?\")'>
-        <input type='hidden' name='form_name' value='remGroup'>
-        <input type='hidden' name='pi' value='" . $pi_group->getPIUID() . "'>
-        <input type='submit' value='Remove'>
-    </form>";
-        echo "</td>";
         echo "</tr>";
     }
     ?>

--- a/webroot/panel/pi.php
+++ b/webroot/panel/pi.php
@@ -30,11 +30,6 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
             $group->removeUser($form_user);
 
             break;
-        case "disband":
-            $group->removeGroup();
-            UnitySite::redirect($CONFIG["site"]["prefix"] . "/panel/account.php");
-
-            break;
     }
 }
 
@@ -110,17 +105,7 @@ foreach ($assocs as $assoc) {
 }
 
 echo "</table>";
-
-echo "<h5>Danger Zone</h5>";
-
-echo
-"<form action='' method='POST' onsubmit='return confirm(\"Are you sure you want to disband your PI group?\")'>
-<input type='hidden' name='form_name' value='disband'>
-<input type='submit' value='Disband PI Account'>
-</form>
-";
 ?>
-</table>
 
 <?php
 include $LOC_FOOTER;


### PR DESCRIPTION
removed the "disband PI group" functionality from HTML, PHP HTTP API, and UnityGroup. also removed a stray `</table>` from the end of `pi.php`.

before: 
![image](https://github.com/user-attachments/assets/f8c3a883-1b96-420b-b196-f0bb4c23cbbe)

after: ![image](https://github.com/user-attachments/assets/e10c233c-310e-4312-9353-ee4d51b14daf)

pi mgmt:

before: ![image](https://github.com/user-attachments/assets/8450e447-4a98-40ed-9783-2c43ec25328b)

after: ![image](https://github.com/user-attachments/assets/2537974f-c8c7-41cc-afc7-2480b7b8efaa)