### PR TITLE
Add ability to cancel request, require confirmation of account policy, fix dubious redirect

### DIFF
--- a/defaults/config.ini.default
+++ b/defaults/config.ini.default
@@ -12,6 +12,7 @@ url = "https://127.0.0.1:8000/"  ; URL of the website
 description = "The Unity Web Portal is a lightweight HPC cluster front-end"  ; Description of the website
 logo = "logo.png"  ; path to logo file, in the webroot/assets/branding folder
 terms_of_service_url = "https://github.com" ; this can be external or a portal page created with "content management"
+account_policy_url = "https://github.com" ; this can be external or a portal page created with "content management"
 
 [ldap]
 uri = "ldap://identity"  ; URI of remote LDAP server

--- a/resources/lib/UnityGroup.php
+++ b/resources/lib/UnityGroup.php
@@ -227,7 +227,8 @@ class UnityGroup
             // send email to requestor
             $this->MAILER->sendMail(
                 $this->getOwner()->getMail(),
-                "group_request_cancelled"
+                "group_join_request_cancelled",
+                ["group" => $this->pi_uid]
             );
         }
     }

--- a/resources/lib/UnityGroup.php
+++ b/resources/lib/UnityGroup.php
@@ -198,6 +198,40 @@ class UnityGroup
         }
     }
 
+    public function cancelGroupRequest($send_mail = true)
+    {
+        if (!$this->SQL->requestExists($this->getOwner()->getUID())) {
+            return;
+        }
+
+        $this->SQL->deleteGroupRequestByUserAndPI($this->getOwner()->getUID(), "admin");
+
+        if ($send_mail) {
+            // send email to requestor
+            $this->MAILER->sendMail(
+                "admin",
+                "group_request_cancelled"
+            );
+        }
+    }
+
+    public function cancelGroupJoinRequest($user, $send_mail = true)
+    {
+        if (!$this->requestExists($user)) {
+            return;
+        }
+
+        $this->SQL->deleteGroupRequestByUserAndPI($user->getUID(), $this->pi_uid);
+
+        if ($send_mail) {
+            // send email to requestor
+            $this->MAILER->sendMail(
+                $this->getOwner()->getMail(),
+                "group_request_cancelled"
+            );
+        }
+    }
+
     // /**
     //  * This method will delete the group, either by admin action or PI action
     //  */

--- a/resources/lib/UnityGroup.php
+++ b/resources/lib/UnityGroup.php
@@ -204,7 +204,7 @@ class UnityGroup
             return;
         }
 
-        $this->SQL->deleteGroupRequestByUserAndPI($this->getOwner()->getUID(), "admin");
+        $this->SQL->removeRequest($this->getOwner()->getUID());
 
         if ($send_mail) {
             // send email to requestor
@@ -221,7 +221,7 @@ class UnityGroup
             return;
         }
 
-        $this->SQL->deleteGroupRequestByUserAndPI($user->getUID(), $this->pi_uid);
+        $this->SQL->removeRequest($user->getUID(), $this->pi_uid);
 
         if ($send_mail) {
             // send email to requestor
@@ -286,7 +286,7 @@ class UnityGroup
         $this->addUserToGroup($new_user);
 
         // remove request, this will fail silently if the request doesn't exist
-        $this->removeRequest($new_user->getUID());
+        $this->SQL->removeRequest($new_user->getUID(), $this->pi_uid);
 
         // send email to the requestor
         if ($send_mail) {
@@ -318,7 +318,7 @@ class UnityGroup
         }
 
         // remove request, this will fail silently if the request doesn't exist
-        $this->removeRequest($new_user->getUID());
+        $this->SQL->removeRequest($new_user->getUID(), $this->pi_uid);
 
         if ($send_mail) {
             // send email to the user
@@ -555,11 +555,6 @@ class UnityGroup
     private function addRequest($uid)
     {
         $this->SQL->addRequest($uid, $this->pi_uid);
-    }
-
-    private function removeRequest($uid)
-    {
-        $this->SQL->removeRequest($uid, $this->pi_uid);
     }
 
     //

--- a/resources/lib/UnityLDAP.php
+++ b/resources/lib/UnityLDAP.php
@@ -38,6 +38,7 @@ class UnityLDAP extends ldapConn
     private $pi_groupOU;
     private $org_groupOU;
     private $adminGroup;
+    private $userGroup;
 
     private $custom_mappings_path;
 

--- a/resources/lib/UnitySQL.php
+++ b/resources/lib/UnitySQL.php
@@ -20,7 +20,7 @@ class UnitySQL
 
 
     // FIXME this string should be changed to something more intuitive, requires production sql change
-    private const REQUEST_BECOME_PI = "admin";
+    public const REQUEST_BECOME_PI = "admin";
 
     private $conn;
 

--- a/resources/lib/UnitySQL.php
+++ b/resources/lib/UnitySQL.php
@@ -53,17 +53,6 @@ class UnitySQL
         $stmt->execute();
     }
 
-    public function deleteGroupRequestByUserAndPI($user, $pi_uid)
-    {
-        $stmt = $this->conn->prepare(
-            "DELETE FROM " . self::TABLE_REQS . " WHERE uid=:uid AND request_for=:request_for"
-        );
-        $stmt->bindParam(":uid", $user);
-        $stmt->bindParam(":request_for", $pi_uid);
-
-        $stmt->execute();
-    }
-
     public function removeRequest($requestor, $dest = self::REQUEST_BECOME_PI)
     {
         if (!$this->requestExists($requestor, $dest)) {

--- a/resources/lib/UnitySQL.php
+++ b/resources/lib/UnitySQL.php
@@ -53,6 +53,17 @@ class UnitySQL
         $stmt->execute();
     }
 
+    public function deleteGroupRequestByUserAndPI($user, $pi_uid)
+    {
+        $stmt = $this->conn->prepare(
+            "DELETE FROM " . self::TABLE_REQS . " WHERE uid=:uid AND request_for=:request_for"
+        );
+        $stmt->bindParam(":uid", $user);
+        $stmt->bindParam(":request_for", $pi_uid);
+
+        $stmt->execute();
+    }
+
     public function removeRequest($requestor, $dest = self::REQUEST_BECOME_PI)
     {
         if (!$this->requestExists($requestor, $dest)) {

--- a/resources/lib/UnitySite.php
+++ b/resources/lib/UnitySite.php
@@ -27,7 +27,7 @@ class UnitySite
     public static function redirect($destination)
     {
         header("Location: $destination");
-        die("Redirect failed, click <a href='$destination'>here</a> to continue.");
+        self::die("Redirect failed, click <a href='$destination'>here</a> to continue.");
     }
 
     private static function headerResponseCode(int $code, string $reason)

--- a/resources/lib/UnitySite.php
+++ b/resources/lib/UnitySite.php
@@ -26,10 +26,8 @@ class UnitySite
 
     public static function redirect($destination)
     {
-        if ($_SERVER["PHP_SELF"] != $destination) {
-            header("Location: $destination");
-            self::die("Redirect failed, click <a href='$destination'>here</a> to continue.");
-        }
+        header("Location: $destination");
+        die("Redirect failed, click <a href='$destination'>here</a> to continue.");
     }
 
     private static function headerResponseCode(int $code, string $reason)

--- a/resources/mail/group_join_request_cancelled.php
+++ b/resources/mail/group_join_request_cancelled.php
@@ -1,0 +1,10 @@
+<?php
+
+// This template is sent to the user cancelling the request
+$this->Subject = "Unity Account Request Cancelled";
+?>
+
+<p>Hello,</p>
+
+<p>Your request for to join <?php echo $data["group"]; ?> on the Unity Cluster has been cancelld per your request.</p>
+

--- a/resources/mail/group_join_request_cancelled.php
+++ b/resources/mail/group_join_request_cancelled.php
@@ -6,5 +6,6 @@ $this->Subject = "Unity Account Request Cancelled";
 
 <p>Hello,</p>
 
-<p>Your request to join group '<?php echo $data["group"]; ?>' on the Unity Cluster has been cancelled per your request.</p>
+<p>Your request to join group '<?php echo $data["group"]; ?>' on the Unity Cluster has been cancelled per your request.
+</p>
 

--- a/resources/mail/group_join_request_cancelled.php
+++ b/resources/mail/group_join_request_cancelled.php
@@ -6,5 +6,5 @@ $this->Subject = "Unity Account Request Cancelled";
 
 <p>Hello,</p>
 
-<p>Your request for to join <?php echo $data["group"]; ?> on the Unity Cluster has been cancelled per your request.</p>
+<p>Your request to join group '<?php echo $data["group"]; ?>' on the Unity Cluster has been cancelled per your request.</p>
 

--- a/resources/mail/group_join_request_cancelled.php
+++ b/resources/mail/group_join_request_cancelled.php
@@ -6,5 +6,5 @@ $this->Subject = "Unity Account Request Cancelled";
 
 <p>Hello,</p>
 
-<p>Your request for to join <?php echo $data["group"]; ?> on the Unity Cluster has been cancelld per your request.</p>
+<p>Your request for to join <?php echo $data["group"]; ?> on the Unity Cluster has been cancelled per your request.</p>
 

--- a/resources/mail/group_request_cancelled.php
+++ b/resources/mail/group_request_cancelled.php
@@ -1,0 +1,10 @@
+<?php
+
+// This template is sent to the user cancelling the request
+$this->Subject = "Unity PI Account Request Cancelled";
+?>
+
+<p>Hello,</p>
+
+<p>Your request for a PI account on the Unity Cluster has been cancelled per your request.</p>
+

--- a/resources/templates/header.php
+++ b/resources/templates/header.php
@@ -11,7 +11,7 @@ if ((@$_SESSION["is_admin"] ?? false) == true
 }
 
 if (isset($SSO)) {
-    if (!$_SESSION["user_exists"]) {
+    if (!$_SESSION["user_exists"] && !str_ends_with($_SERVER['PHP_SELF'], "/panel/new_account.php")) {
         UnitySite::redirect($CONFIG["site"]["prefix"] . "/panel/new_account.php");
     }
 }

--- a/test/functional/CancelRequestTest.php
+++ b/test/functional/CancelRequestTest.php
@@ -19,7 +19,7 @@ class CancelRequestTest extends TestCase
         try {
             http_post(
                 __DIR__ . "/../../webroot/panel/new_account.php",
-                ["new_user_sel" => "pi", "eula" => "agree"]
+                ["new_user_sel" => "pi", "eula" => "agree", "confirm_pi" => "agree"]
             );
         } catch (PhpUnitNoDieException $e) {
             // Ignore the exception from http_post
@@ -29,9 +29,9 @@ class CancelRequestTest extends TestCase
 
         // Now try to cancel it
         try {
-            http_get(
+            http_post(
                 __DIR__ . "/../../webroot/panel/new_account.php",
-                ["cancel" => "true"]
+                ["cancel" => "true"] # value of cancel is arbitrary
             );
         } catch (PhpUnitNoDieException $e) {
             // Ignore the exception from http_post
@@ -58,9 +58,9 @@ class CancelRequestTest extends TestCase
 
         // Now try to cancel it
         try {
-            http_get(
+            http_post(
                 __DIR__ . "/../../webroot/panel/new_account.php",
-                ["cancel" => "true"]
+                ["cancel" => "true"] # value of cancel is arbitrary
             );
         } catch (PhpUnitNoDieException $e) {
             // Ignore the exception from http_post

--- a/test/functional/CancelRequestTest.php
+++ b/test/functional/CancelRequestTest.php
@@ -1,0 +1,71 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use UnityWebPortal\lib\exceptions\PhpUnitNoDieException;
+
+class CancelRequestTest extends TestCase
+{
+    private function assertNumberGroupRequests(int $x)
+    {
+        global $USER, $SQL;
+        $this->assertEquals($x, count($SQL->getRequestsByUser($USER->getUID())));
+    }
+
+    public function testCancelPIRequest()
+    {
+        global $USER, $SQL;
+        switchUser(...getNonExistentUser());
+        // First create a request
+        try {
+            http_post(
+                __DIR__ . "/../../webroot/panel/new_account.php",
+                ["new_user_sel" => "pi", "eula" => "agree"]
+            );
+        } catch (PhpUnitNoDieException $e) {
+            // Ignore the exception from http_post
+        }
+
+        $this->assertNumberGroupRequests(1);
+
+        // Now try to cancel it
+        try {
+            http_get(
+                __DIR__ . "/../../webroot/panel/new_account.php",
+                ["cancel" => "true"]
+            );
+        } catch (PhpUnitNoDieException $e) {
+            // Ignore the exception from http_post
+        }
+
+        $this->assertNumberGroupRequests(0);
+    }
+
+    public function testCancelGroupJoinRequest()
+    {
+        global $USER, $SQL;
+        switchUser(...getNonExistentUser());
+
+        try {
+            http_post(
+                __DIR__ . "/../../webroot/panel/new_account.php",
+                ["new_user_sel" => "not_pi", "eula" => "agree", "pi" => getExistingPI()]
+            );
+        } catch (PhpUnitNoDieException $e) {
+            // Ignore the exception from http_post
+        }
+
+        $this->assertNumberGroupRequests(1);
+
+        // Now try to cancel it
+        try {
+            http_get(
+                __DIR__ . "/../../webroot/panel/new_account.php",
+                ["cancel" => "true"]
+            );
+        } catch (PhpUnitNoDieException $e) {
+            // Ignore the exception from http_post
+        }
+
+        $this->assertNumberGroupRequests(0);
+    }
+}

--- a/test/phpunit-bootstrap.php
+++ b/test/phpunit-bootstrap.php
@@ -159,7 +159,7 @@ function getUserIsPIHasAtLeastOneMember()
 
 function getNonExistentUser()
 {
-    return ["user1@nonexistent.test", "foo", "bar", "user1@nonexistent.test"];
+    return ["user2000@org2.test", "foo", "bar", "user2000@org2.test"];
 }
 
 function getAdminUser()

--- a/test/phpunit-bootstrap.php
+++ b/test/phpunit-bootstrap.php
@@ -76,7 +76,9 @@ function switchUser(
 function http_post(string $phpfile, array $post_data): void
 {
     global $CONFIG, $REDIS, $LDAP, $SQL, $MAILER, $WEBHOOK, $GITHUB, $SITE, $SSO, $OPERATOR, $USER, $SEND_PIMESG_TO_ADMINS, $LOC_HEADER, $LOC_FOOTER;
+    $_PREVIOUS_SERVER = $_SERVER;
     $_SERVER["REQUEST_METHOD"] = "POST";
+    $_SERVER["PHP_SELF"] = preg_replace("/.*webroot\//", "/", $phpfile);
     $_POST = $post_data;
     ob_start();
     try {
@@ -84,20 +86,24 @@ function http_post(string $phpfile, array $post_data): void
     } finally {
         ob_get_clean(); // discard output
         unset($_POST);
-        unset($_SERVER["REQUEST_METHOD"]);
+        $_SERVER = $_PREVIOUS_SERVER;
     }
 }
 
-function http_get(string $phpfile): void
+function http_get(string $phpfile, array $get_data): void
 {
     global $CONFIG, $REDIS, $LDAP, $SQL, $MAILER, $WEBHOOK, $GITHUB, $SITE, $SSO, $OPERATOR, $USER, $SEND_PIMESG_TO_ADMINS, $LOC_HEADER, $LOC_FOOTER;
+    $_PREVIOUS_SERVER = $_SERVER;
     $_SERVER["REQUEST_METHOD"] = "GET";
+    $_SERVER["PHP_SELF"] = preg_replace("/.*webroot\//", "/", $phpfile);
+    $_GET = $get_data;
     ob_start();
     try {
         include $phpfile;
     } finally {
         ob_get_clean(); // discard output
-        unset($_SERVER["REQUEST_METHOD"]);
+        unset($_GET);
+        $_PREVIOUS_SERVER = $_SERVER;
     }
 }
 
@@ -159,4 +165,9 @@ function getNonExistentUser()
 function getAdminUser()
 {
     return ["user1@org1.test", "foo", "bar", "user1@org1.test"];
+}
+
+function getExistingPI()
+{
+    return "pi_user1005_org3_test";
 }

--- a/test/phpunit-bootstrap.php
+++ b/test/phpunit-bootstrap.php
@@ -90,7 +90,7 @@ function http_post(string $phpfile, array $post_data): void
     }
 }
 
-function http_get(string $phpfile, array $get_data): void
+function http_get(string $phpfile, array $get_data = array()): void
 {
     global $CONFIG, $REDIS, $LDAP, $SQL, $MAILER, $WEBHOOK, $GITHUB, $SITE, $SSO, $OPERATOR, $USER, $SEND_PIMESG_TO_ADMINS, $LOC_HEADER, $LOC_FOOTER;
     $_PREVIOUS_SERVER = $_SERVER;

--- a/test/unit/UnityGithubTest.php
+++ b/test/unit/UnityGithubTest.php
@@ -17,7 +17,7 @@ class UnityGithubTest extends TestCase
             # user with no keys
             ["sheldor1510", []],
             # user with 1 key
-            ["simonLeary42", ["ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDGRl6JWPj+Gq2Lz9GjYdUl4/unLoFOyfgeiII1CxutpabPByRJbeuonR0zTpn51tZeYuAUOJBOeKt+Lj4i4UDGl6igpdXXSwkBXl7jxfRPwJ6WuTkDx7Z8ynwnqlDV2q089q4OX/b/uuHgsIhIBwrouKsRQaZIqTbwNMfiqQ2zl14V0KMrTPzOiwR6Q+hqSaR5Z29WKE7ff/OWzSC3/0T6avCmcCbQaRPJdVM+QC17B0vl8FzPwRjorMngwZ0cImdQ/0Ww1d12YAL7UWp1c2egfnthKP3MuQZnNF8ixsAk1eIIwTRdiI87BOoorW8NXhxXmhyheRCsFwyP4LJBqyUVoZJ0UYyk0AO4G9EStnfpiz8YXGK+M1G4tUrWgzs1cdjlHtgCWUmITtgabnYCC4141m7n4GZTk2H/lSrJcvAs3JEiwLTj1lzeGgzeSsz/XKsnOJyzjEVr2Jp3iT+J9PbQpfS0SxTCIGgxMqllovv79pfsF/zc+vaxqSShyHW7oyn7hLMHM60LO/IIX1RWGL3rD9ecXx2pXXQ1RhIkVteIi13XkFt+KW00cstFlAd3EHCoY/XorShd2jeID7tpnYlmNfotYUs6IKefvpNC0PWkh5UXFEv3SUfw4Wd8O0DiHfhkrhxn1W/GajqSIlZ5DKgPzFg8EHexv8lSa7WJg0H3YQ=="]]
+            ["simonLeary42", ["ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBL2oMxcq04PWw1iB2ZQZezFPGmX2HEKhHD6kLIoLz1RUKTNN7Glw2iF5uMFnKxYgTvdfrNjrvvLnOXvhPBvjeec="]]
         ];
     }
 

--- a/webroot/panel/new_account.php
+++ b/webroot/panel/new_account.php
@@ -94,12 +94,6 @@ if (isset($_GET['cancel']) && count($pending_requests) > 0) {
         <hr>
 
         <label><input type='radio' name='new_user_sel' value='pi'>Request a PI account</label>
-        <div style='position: relative;display: none;' id='piConfirmWrapper'>
-        <label><input type='checkbox' id='chk_pi' name='confirm_pi' value='agree'>
-           I have read the PI <a href="<?php echo $CONFIG["site"]["account_policy_url"]; ?>">
-            account policy</a> guidelines. </label>
-        </div>
-        <br>
         <label><input type='radio' name='new_user_sel' value='not_pi' checked>Join an existing PI group</label>
 
         <div style='position: relative;' id='piSearchWrapper'>
@@ -109,9 +103,16 @@ if (isset($_GET['cancel']) && count($pending_requests) > 0) {
 
         <hr>
 
+        <div style='position: relative;display: none;' id='piConfirmWrapper'>
+        <label><input type='checkbox' id='chk_pi' name='confirm_pi' value='agree'>
+           I have read the PI <a href="<?php echo $CONFIG["site"]["account_policy_url"]; ?>">
+            account policy</a> guidelines. </label>
+        </div>
+        <br>
+
         <label><input type='checkbox' id='chk_eula' name='eula' value='agree' required>
             I have read and accept the <a target='_blank' href='<?php echo $CONFIG["site"]["terms_of_service_url"]; ?>'>
-                Unity Terms of Service</a></label>
+                Unity Terms of Service</a>.</label>
 
         <br>
         <input style='margin-top: 10px;' type='submit' value='Request Account'>

--- a/webroot/panel/new_account.php
+++ b/webroot/panel/new_account.php
@@ -6,7 +6,6 @@ use UnityWebPortal\lib\UnitySite;
 use UnityWebPortal\lib\UnityGroup;
 
 require_once $LOC_HEADER;
-
 if ($USER->exists()) {
     UnitySite::redirect($CONFIG["site"]["prefix"] . "/panel/index.php");  // Redirect if account already exists
 }
@@ -27,7 +26,6 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
             array_push($errors, "The selected PI does not exist");
         }
     }
-
     // Request Account Form was Submitted
     if (count($errors) == 0) {
         if ($_POST["new_user_sel"] == "pi") {
@@ -37,13 +35,12 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
             $form_group->newUserRequest($USER);
         }
     }
-    header("Location: ${_SERVER['PHP_SELF']}");
-    die();
+    header("Location: {$_SERVER['PHP_SELF']}");
+    UnitySite::die();
 }
 
 if (isset($_GET['cancel']) && count($pending_requests) > 0) {
     foreach ($pending_requests as $request) {
-        print("cancelling");
         if ($request["request_for"] == "admin") {
             // cancel PI request
             $pi_group = new UnityGroup(UnityGroup::getPIUIDfromUID($USER->getUID()), $LDAP, $SQL, $MAILER, $REDIS, $WEBHOOK);
@@ -54,8 +51,8 @@ if (isset($_GET['cancel']) && count($pending_requests) > 0) {
             $pi_group->cancelGroupJoinRequest($user=$USER);
         }
     }
-    header("Location: ${_SERVER['PHP_SELF']}");
-    die();
+    header("Location: {$_SERVER['PHP_SELF']}");
+    UnitySite::die();
 }
 
 ?>

--- a/webroot/panel/new_account.php
+++ b/webroot/panel/new_account.php
@@ -46,10 +46,7 @@ if (isset($_GET['cancel']) && count($pending_requests) > 0) {
     foreach ($pending_requests as $request) {
         if ($request["request_for"] == "admin") {
             // cancel PI request
-            $pi_group = new UnityGroup(UnityGroup::getPIUIDfromUID(
-                $USER->getUID()
-            ), $LDAP, $SQL, $MAILER, $REDIS, $WEBHOOK);
-            $pi_group->cancelGroupRequest();
+            $USER->getPIGroup()->cancelGroupRequest();
         } else {
             $pi_group = new UnityGroup($request["request_for"], $LDAP, $SQL, $MAILER, $REDIS, $WEBHOOK);
             $pi_group->cancelGroupJoinRequest($user=$USER);

--- a/webroot/panel/new_account.php
+++ b/webroot/panel/new_account.php
@@ -43,10 +43,11 @@ if (isset($_GET['cancel']) && count($pending_requests) > 0) {
     foreach ($pending_requests as $request) {
         if ($request["request_for"] == "admin") {
             // cancel PI request
-            $pi_group = new UnityGroup(UnityGroup::getPIUIDfromUID($USER->getUID()), $LDAP, $SQL, $MAILER, $REDIS, $WEBHOOK);
+            $pi_group = new UnityGroup(UnityGroup::getPIUIDfromUID(
+                $USER->getUID()
+            ), $LDAP, $SQL, $MAILER, $REDIS, $WEBHOOK);
             $pi_group->cancelGroupRequest();
-        }
-        else {
+        } else {
             $pi_group = new UnityGroup($request["request_for"], $LDAP, $SQL, $MAILER, $REDIS, $WEBHOOK);
             $pi_group->cancelGroupJoinRequest($user=$USER);
         }
@@ -60,24 +61,26 @@ if (isset($_GET['cancel']) && count($pending_requests) > 0) {
 <h1>Request Account</h1>
 <hr>
 
-<?php if (count($pending_requests) > 0): ?>
+<?php if (count($pending_requests) > 0) : ?>
     <p>You have pending account activation requests:</p>
-    <?php foreach ($pending_requests as $request): ?>
+    <?php foreach ($pending_requests as $request) : ?>
         <?php
             $pi_uid = $request["request_for"];
-            if ($pi_uid == "admin") {
-                echo "<p>Requesting a PI account</p>";
-                echo "<p>You will receive an email when your account has been approved.</p><p>Email <a href=\"mailto:{$CONFIG['mail']['support']}\">{$CONFIG['mail']['support_name']}</a> if you have not heard back in one business day. </p>";
-            } else {
-                $owner_uid = UnityGroup::getUIDfromPIUID($pi_uid);
-                echo "<p>Joining existing group owned by " . $owner_uid . "</p>";
-                echo "<p>You will receive an email when your account has been approved by the PI. You may need to remind them.</p>";
-            }
+        if ($pi_uid == "admin") {
+            echo "<p>Requesting a PI account</p>";
+            echo "<p>You will receive an email when your account has been approved.</p>";
+            echo "<p>Email <a href=\"mailto:{$CONFIG['mail']['support']}\">{$CONFIG['mail']['support_name']}</a>";
+            echo "if you have not heard back in one business day. </p>";
+        } else {
+            $owner_uid = UnityGroup::getUIDfromPIUID($pi_uid);
+            echo "<p>Joining existing group owned by " . $owner_uid . "</p>";
+            echo "<p>You will receive an email when your account has been approved by the PI.";
+            echo "You may need to remind them.</p>";
+        }
         ?>
         <a href="?cancel=true">Cancel Request</a>
     <?php endforeach; ?>
-<?php else: ?>
-
+<?php else : ?>
     <form id="newAccountForm" action="" method="POST">
         <p>Please verify that the information below is correct before continuing</p>
         <div>

--- a/webroot/panel/new_account.php
+++ b/webroot/panel/new_account.php
@@ -39,8 +39,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
             $form_group->newUserRequest($USER);
         }
     }
-    header("Location: {$_SERVER['PHP_SELF']}");
-    UnitySite::die();
+    UnitySite::redirect($_SERVER['PHP_SELF']);
 }
 
 if (isset($_GET['cancel']) && count($pending_requests) > 0) {
@@ -56,8 +55,7 @@ if (isset($_GET['cancel']) && count($pending_requests) > 0) {
             $pi_group->cancelGroupJoinRequest($user=$USER);
         }
     }
-    header("Location: {$_SERVER['PHP_SELF']}");
-    UnitySite::die();
+    UnitySite::redirect($_SERVER['PHP_SELF']);
 }
 
 ?>
@@ -74,7 +72,7 @@ if (isset($_GET['cancel']) && count($pending_requests) > 0) {
             echo "<p>Requesting a PI account</p>";
             echo "<p>You will receive an email when your account has been approved.</p>";
             echo "<p>Email <a href=\"mailto:{$CONFIG['mail']['support']}\">{$CONFIG['mail']['support_name']}</a>";
-            echo "if you have not heard back in one business day. </p>";
+            echo " if you have not heard back in one business day. </p>";
         } else {
             $owner_uid = UnityGroup::getUIDfromPIUID($pi_uid);
             echo "<p>Joining existing group owned by " . $owner_uid . "</p>";
@@ -100,7 +98,7 @@ if (isset($_GET['cancel']) && count($pending_requests) > 0) {
 
         <label><input type='radio' name='new_user_sel' value='pi'>Request a PI account</label>
         <div style='position: relative;display: none;' id='piConfirmWrapper'>
-        <label><input type='checkbox' id='chk_pi' name='confirm_pi' value='agree' required>
+        <label><input type='checkbox' id='chk_pi' name='confirm_pi' value='agree'>
            I have read the PI <a href="<?php echo $CONFIG["site"]["account_policy_url"]; ?>">
             account policy</a> guidelines. </label>
         </div>

--- a/webroot/panel/new_account.php
+++ b/webroot/panel/new_account.php
@@ -29,6 +29,10 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     // Request Account Form was Submitted
     if (count($errors) == 0) {
         if ($_POST["new_user_sel"] == "pi") {
+            if (!isset($_POST["chk_pi"]) || $_POST["chk_pi"] != "agree") {
+                // checkbox was not checked
+                array_push($errors, "Please confirm you have read the account policy guidelines.");
+            }
             // requesting a PI account
             $USER->getPIGroup()->requestGroup($SEND_PIMESG_TO_ADMINS);
         } elseif ($_POST["new_user_sel"] == "not_pi") {
@@ -94,7 +98,12 @@ if (isset($_GET['cancel']) && count($pending_requests) > 0) {
 
         <hr>
 
-        <label><input type='radio' name='new_user_sel' value='pi'>Request a PI account (I am a PI)</label>
+        <label><input type='radio' name='new_user_sel' value='pi'>Request a PI account</label>
+        <div style='position: relative;display: none;' id='piConfirmWrapper'>
+        <label><input type='checkbox' id='chk_pi' name='confirm_pi' value='agree' required>
+           I have read the PI <a href="<?php echo $CONFIG["site"]["account_policy_url"]; ?>">
+            account policy</a> guidelines. </label>
+        </div>
         <br>
         <label><input type='radio' name='new_user_sel' value='not_pi' checked>Join an existing PI group</label>
 
@@ -126,12 +135,17 @@ if (isset($_GET['cancel']) && count($pending_requests) > 0) {
 
 <script>
     $('input[type=radio][name=new_user_sel]').change(function() {
+        let pi_cnf_text = $('#piConfirmWrapper');
         let pi_sel_text = $('#piSearchWrapper');
         if (this.value == 'not_pi') {
+            pi_cnf_text.hide();
             pi_sel_text.show();
+            $("#chk_pi").prop("required", false);
             $("#pi_search").prop("required", true);
         } else if (this.value == 'pi') {
+            pi_cnf_text.show();
             pi_sel_text.hide();
+            $("#chk_pi").prop("required", true);
             $("#pi_search").prop("required", false);
         }
     });

--- a/webroot/panel/new_account.php
+++ b/webroot/panel/new_account.php
@@ -4,57 +4,48 @@ require_once __DIR__ . "/../../resources/autoload.php";
 
 use UnityWebPortal\lib\UnitySite;
 use UnityWebPortal\lib\UnityGroup;
+use UnityWebPortal\lib\UnitySQL;
 
-require_once $LOC_HEADER;
 if ($USER->exists()) {
-    UnitySite::redirect($CONFIG["site"]["prefix"] . "/panel/index.php");  // Redirect if account already exists
+    UnitySite::redirect($CONFIG["site"]["prefix"] . "/panel/index.php");
 }
 
 $pending_requests = $SQL->getRequestsByUser($USER->getUID());
 
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
-    $errors = array();
-
-    if (!isset($_POST["eula"]) || $_POST["eula"] != "agree") {
-        // checkbox was not checked
-        array_push($errors, "Accepting the EULA is required");
-    }
-
-    if ($_POST["new_user_sel"] == "not_pi") {
-        $form_group = new UnityGroup($_POST["pi"], $LDAP, $SQL, $MAILER, $REDIS, $WEBHOOK);
-        if (!$form_group->exists()) {
-            array_push($errors, "The selected PI does not exist");
+    if (isset($_POST["new_user_sel"])) {
+        if (!isset($_POST["eula"]) || $_POST["eula"] != "agree") {
+            UnitySite::badRequest("user did not agree to EULA");
         }
-    }
-    // Request Account Form was Submitted
-    if (count($errors) == 0) {
-        if ($_POST["new_user_sel"] == "pi") {
-            if (!isset($_POST["chk_pi"]) || $_POST["chk_pi"] != "agree") {
-                // checkbox was not checked
-                array_push($errors, "Please confirm you have read the account policy guidelines.");
+        if ($_POST["new_user_sel"] == "not_pi") {
+            $form_group = new UnityGroup($_POST["pi"], $LDAP, $SQL, $MAILER, $REDIS, $WEBHOOK);
+            if (!$form_group->exists()) {
+                UnitySite::badRequest("The selected PI does not exist");
             }
-            // requesting a PI account
-            $USER->getPIGroup()->requestGroup($SEND_PIMESG_TO_ADMINS);
-        } elseif ($_POST["new_user_sel"] == "not_pi") {
             $form_group->newUserRequest($USER);
         }
-    }
-    UnitySite::redirect($_SERVER['PHP_SELF']);
-}
-
-if (isset($_GET['cancel']) && count($pending_requests) > 0) {
-    foreach ($pending_requests as $request) {
-        if ($request["request_for"] == "admin") {
-            // cancel PI request
-            $USER->getPIGroup()->cancelGroupRequest();
-        } else {
-            $pi_group = new UnityGroup($request["request_for"], $LDAP, $SQL, $MAILER, $REDIS, $WEBHOOK);
-            $pi_group->cancelGroupJoinRequest($user=$USER);
+        if ($_POST["new_user_sel"] == "pi") {
+            if (!isset($_POST["confirm_pi"]) || $_POST["confirm_pi"] != "agree") {
+                UnitySite::badRequest("user did not agree to account policy");
+            }
+            $USER->getPIGroup()->requestGroup($SEND_PIMESG_TO_ADMINS);
         }
     }
+    elseif (isset($_POST["cancel"])) {
+        foreach ($pending_requests as $request) {
+            if ($request["request_for"] == "admin") {
+                $USER->getPIGroup()->cancelGroupRequest();
+            } else {
+                $pi_group = new UnityGroup($request["request_for"], $LDAP, $SQL, $MAILER, $REDIS, $WEBHOOK);
+                $pi_group->cancelGroupJoinRequest($user=$USER);
+            }
+        }
+    } else {
+        UnitySite::badRequest("neither 'new_user_sel' or 'cancel' are set!");
+    }
     UnitySite::redirect($_SERVER['PHP_SELF']);
 }
-
+require_once $LOC_HEADER;
 ?>
 
 <h1>Request Account</h1>
@@ -63,21 +54,30 @@ if (isset($_GET['cancel']) && count($pending_requests) > 0) {
 <?php if (count($pending_requests) > 0) : ?>
     <p>You have pending account activation requests:</p>
     <?php foreach ($pending_requests as $request) : ?>
+        <ul><li>
         <?php
-            $pi_uid = $request["request_for"];
-        if ($pi_uid == "admin") {
-            echo "<p>Requesting a PI account</p>";
-            echo "<p>You will receive an email when your account has been approved.</p>";
-            echo "<p>Email <a href=\"mailto:{$CONFIG['mail']['support']}\">{$CONFIG['mail']['support_name']}</a>";
-            echo " if you have not heard back in one business day. </p>";
+        $pi_uid = $request["request_for"];
+        if ($pi_uid == UnitySQL::REQUEST_BECOME_PI) {
+            $group_uid = $USER->getPIGroup()->getPIUID();
+            echo "<p>Ownership of PI Account/Group: <code>$group_uid</code> </p>";
         } else {
             $owner_uid = UnityGroup::getUIDfromPIUID($pi_uid);
-            echo "<p>Joining existing group owned by " . $owner_uid . "</p>";
-            echo "<p>You will receive an email when your account has been approved by the PI.";
-            echo "You may need to remind them.</p>";
+            echo "<p>Membership in PI Group owned by: <code>$owner_uid</code></p>";
         }
         ?>
-        <a href="?cancel=true">Cancel Request</a>
+        </li></ul>
+        <hr>
+        <p><strong>Requesting Ownership of PI Account/Group</strong></p>
+        <p>You will receive an email when your account has been approved.</p>
+        <p>Email <a href="mailto:<?php echo $CONFIG['mail']['support']; ?>"><?php echo $CONFIG['mail']['support_name']; ?></a> if you have not heard back in one business day. </p>
+        <br>
+        <p><strong>Requesting Membership in a PI Group</strong></p>
+        <p>You will receive an email when your account has been approved by the PI.</p>
+        <p>You may need to remind them.</p>
+        <hr>
+        <form action="" method="POST">
+            <input name="cancel" style='margin-top: 10px;' type='submit' value='Cancel Request'/>
+        </form>
     <?php endforeach; ?>
 <?php else : ?>
     <form id="newAccountForm" action="" method="POST">
@@ -116,16 +116,6 @@ if (isset($_GET['cancel']) && count($pending_requests) > 0) {
 
         <br>
         <input style='margin-top: 10px;' type='submit' value='Request Account'>
-
-        <?php
-        if (isset($errors)) {
-            echo "<div class='message'>";
-            foreach ($errors as $err) {
-                echo "<p class='message-failure'>" . $err . "</p>";
-            }
-            echo "</div>";
-        }
-        ?>
     </form>
 <?php endif; ?>
 


### PR DESCRIPTION
Modify the new_account page to allow a user without an account to cancel a pending request for either a PI account or joining a group.