### PR TITLE
Cancel2

### DIFF
--- a/resources/lib/UnitySQL.php
+++ b/resources/lib/UnitySQL.php
@@ -20,7 +20,7 @@ class UnitySQL
 
 
     // FIXME this string should be changed to something more intuitive, requires production sql change
-    private const REQUEST_BECOME_PI = "admin";
+    public const REQUEST_BECOME_PI = "admin";
 
     private $conn;
 

--- a/test/phpunit-bootstrap.php
+++ b/test/phpunit-bootstrap.php
@@ -159,7 +159,7 @@ function getUserIsPIHasAtLeastOneMember()
 
 function getNonExistentUser()
 {
-    return ["user1@nonexistent.test", "foo", "bar", "user1@nonexistent.test"];
+    return ["user2000@org2.test", "foo", "bar", "user2000@org2.test"];
 }
 
 function getAdminUser()

--- a/webroot/panel/new_account.php
+++ b/webroot/panel/new_account.php
@@ -94,12 +94,6 @@ if (isset($_GET['cancel']) && count($pending_requests) > 0) {
         <hr>
 
         <label><input type='radio' name='new_user_sel' value='pi'>Request a PI account</label>
-        <div style='position: relative;display: none;' id='piConfirmWrapper'>
-        <label><input type='checkbox' id='chk_pi' name='confirm_pi' value='agree'>
-           I have read the PI <a href="<?php echo $CONFIG["site"]["account_policy_url"]; ?>">
-            account policy</a> guidelines. </label>
-        </div>
-        <br>
         <label><input type='radio' name='new_user_sel' value='not_pi' checked>Join an existing PI group</label>
 
         <div style='position: relative;' id='piSearchWrapper'>
@@ -108,6 +102,13 @@ if (isset($_GET['cancel']) && count($pending_requests) > 0) {
         </div>
 
         <hr>
+
+        <div style='position: relative;display: none;' id='piConfirmWrapper'>
+        <label><input type='checkbox' id='chk_pi' name='confirm_pi' value='agree'>
+           I have read the PI <a href="<?php echo $CONFIG["site"]["account_policy_url"]; ?>">
+            account policy</a> guidelines. </label>
+        </div>
+        <br>
 
         <label><input type='checkbox' id='chk_eula' name='eula' value='agree' required>
             I have read and accept the <a target='_blank' href='<?php echo $CONFIG["site"]["terms_of_service_url"]; ?>'>

--- a/webroot/panel/new_account.php
+++ b/webroot/panel/new_account.php
@@ -1,10 +1,10 @@
 <?php
 
+require_once __DIR__ . "/../../resources/autoload.php";
+
 use UnityWebPortal\lib\UnitySite;
 use UnityWebPortal\lib\UnityGroup;
 use UnityWebPortal\lib\UnitySQL;
-
-require_once __DIR__ . "/../../resources/autoload.php";
 
 if ($USER->exists()) {
     UnitySite::redirect($CONFIG["site"]["prefix"] . "/panel/index.php");

--- a/webroot/panel/new_account.php
+++ b/webroot/panel/new_account.php
@@ -118,16 +118,6 @@ require_once $LOC_HEADER;
 
         <br>
         <input style='margin-top: 10px;' type='submit' value='Request Account'>
-
-        <?php
-        if (isset($errors)) {
-            echo "<div class='message'>";
-            foreach ($errors as $err) {
-                echo "<p class='message-failure'>" . $err . "</p>";
-            }
-            echo "</div>";
-        }
-        ?>
     </form>
 <?php endif; ?>
 

--- a/webroot/panel/new_account.php
+++ b/webroot/panel/new_account.php
@@ -13,7 +13,6 @@ if ($USER->exists()) {
 $pending_requests = $SQL->getRequestsByUser($USER->getUID());
 
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
-    echo json_encode($_POST);
     if (isset($_POST["new_user_sel"])) {
         if (($_POST["eula"] ?? "disagree") != "agree") {
             UnitySite::badRequest("user did not agree to EULA");

--- a/webroot/panel/new_account.php
+++ b/webroot/panel/new_account.php
@@ -14,7 +14,7 @@ $pending_requests = $SQL->getRequestsByUser($USER->getUID());
 
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
     if (isset($_POST["new_user_sel"])) {
-        if (($_POST["eula"] ?? "disagree") != "agree") {
+        if (!isset($_POST["eula"]) || $_POST["eula"] != "agree") {
             UnitySite::badRequest("user did not agree to EULA");
         }
         if ($_POST["new_user_sel"] == "not_pi") {
@@ -25,7 +25,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
             $form_group->newUserRequest($USER);
         }
         if ($_POST["new_user_sel"] == "pi") {
-            if (($_POST["confirm_pi"] ?? "disagree") != "agree") {
+        if (!isset($_POST["confirm_pi"]) || $_POST["confirm_pi"] != "agree") {
                 UnitySite::badRequest("user did not agree to account policy");
             }
             $USER->getPIGroup()->requestGroup($SEND_PIMESG_TO_ADMINS);

--- a/webroot/panel/new_account.php
+++ b/webroot/panel/new_account.php
@@ -111,7 +111,7 @@ if (isset($_GET['cancel']) && count($pending_requests) > 0) {
 
         <label><input type='checkbox' id='chk_eula' name='eula' value='agree' required>
             I have read and accept the <a target='_blank' href='<?php echo $CONFIG["site"]["terms_of_service_url"]; ?>'>
-                Unity Terms of Service</a></label>
+                Unity Terms of Service</a>.</label>
 
         <br>
         <input style='margin-top: 10px;' type='submit' value='Request Account'>

--- a/webroot/panel/new_account.php
+++ b/webroot/panel/new_account.php
@@ -40,7 +40,6 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
                 $pi_group->cancelGroupJoinRequest($user=$USER);
             }
         }
-        UnitySite::redirect($_SERVER['PHP_SELF']);
     } else {
         UnitySite::badRequest("neither 'new_user_sel' or 'cancel' are set!");
     }

--- a/webroot/panel/new_account.php
+++ b/webroot/panel/new_account.php
@@ -1,60 +1,53 @@
 <?php
 
-require_once __DIR__ . "/../../resources/autoload.php";
-
 use UnityWebPortal\lib\UnitySite;
 use UnityWebPortal\lib\UnityGroup;
+use UnityWebPortal\lib\UnitySQL;
 
-require_once $LOC_HEADER;
+require_once __DIR__ . "/../../resources/autoload.php";
+
 if ($USER->exists()) {
-    UnitySite::redirect($CONFIG["site"]["prefix"] . "/panel/index.php");  // Redirect if account already exists
+    UnitySite::redirect($CONFIG["site"]["prefix"] . "/panel/index.php");
 }
 
 $pending_requests = $SQL->getRequestsByUser($USER->getUID());
 
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
-    $errors = array();
-
-    if (!isset($_POST["eula"]) || $_POST["eula"] != "agree") {
-        // checkbox was not checked
-        array_push($errors, "Accepting the EULA is required");
-    }
-
-    if ($_POST["new_user_sel"] == "not_pi") {
-        $form_group = new UnityGroup($_POST["pi"], $LDAP, $SQL, $MAILER, $REDIS, $WEBHOOK);
-        if (!$form_group->exists()) {
-            array_push($errors, "The selected PI does not exist");
+    echo json_encode($_POST);
+    if (isset($_POST["new_user_sel"])) {
+        if (($_POST["eula"] ?? "disagree") != "agree") {
+            UnitySite::badRequest("user did not agree to EULA");
         }
-    }
-    // Request Account Form was Submitted
-    if (count($errors) == 0) {
-        if ($_POST["new_user_sel"] == "pi") {
-            if (!isset($_POST["chk_pi"]) || $_POST["chk_pi"] != "agree") {
-                // checkbox was not checked
-                array_push($errors, "Please confirm you have read the account policy guidelines.");
+        if ($_POST["new_user_sel"] == "not_pi") {
+            $form_group = new UnityGroup($_POST["pi"], $LDAP, $SQL, $MAILER, $REDIS, $WEBHOOK);
+            if (!$form_group->exists()) {
+                UnitySite::badRequest("The selected PI does not exist");
             }
-            // requesting a PI account
-            $USER->getPIGroup()->requestGroup($SEND_PIMESG_TO_ADMINS);
-        } elseif ($_POST["new_user_sel"] == "not_pi") {
             $form_group->newUserRequest($USER);
         }
-    }
-    UnitySite::redirect($_SERVER['PHP_SELF']);
-}
-
-if (isset($_GET['cancel']) && count($pending_requests) > 0) {
-    foreach ($pending_requests as $request) {
-        if ($request["request_for"] == "admin") {
-            // cancel PI request
-            $USER->getPIGroup()->cancelGroupRequest();
-        } else {
-            $pi_group = new UnityGroup($request["request_for"], $LDAP, $SQL, $MAILER, $REDIS, $WEBHOOK);
-            $pi_group->cancelGroupJoinRequest($user=$USER);
+        if ($_POST["new_user_sel"] == "pi") {
+            if (($_POST["confirm_pi"] ?? "disagree") != "agree") {
+                UnitySite::badRequest("user did not agree to account policy");
+            }
+            $USER->getPIGroup()->requestGroup($SEND_PIMESG_TO_ADMINS);
         }
     }
+    else if (isset($_POST["cancel"])) {
+        foreach ($pending_requests as $request) {
+            if ($request["request_for"] == "admin") {
+                $USER->getPIGroup()->cancelGroupRequest();
+            } else {
+                $pi_group = new UnityGroup($request["request_for"], $LDAP, $SQL, $MAILER, $REDIS, $WEBHOOK);
+                $pi_group->cancelGroupJoinRequest($user=$USER);
+            }
+        }
+        UnitySite::redirect($_SERVER['PHP_SELF']);
+    } else {
+        UnitySite::badRequest("neither 'new_user_sel' or 'cancel' are set!");
+    }
     UnitySite::redirect($_SERVER['PHP_SELF']);
 }
-
+require_once $LOC_HEADER;
 ?>
 
 <h1>Request Account</h1>
@@ -63,21 +56,30 @@ if (isset($_GET['cancel']) && count($pending_requests) > 0) {
 <?php if (count($pending_requests) > 0) : ?>
     <p>You have pending account activation requests:</p>
     <?php foreach ($pending_requests as $request) : ?>
+        <ul><li>
         <?php
-            $pi_uid = $request["request_for"];
-        if ($pi_uid == "admin") {
-            echo "<p>Requesting a PI account</p>";
-            echo "<p>You will receive an email when your account has been approved.</p>";
-            echo "<p>Email <a href=\"mailto:{$CONFIG['mail']['support']}\">{$CONFIG['mail']['support_name']}</a>";
-            echo " if you have not heard back in one business day. </p>";
+        $pi_uid = $request["request_for"];
+        if ($pi_uid == UnitySQL::REQUEST_BECOME_PI) {
+            $group_uid = $USER->getPIGroup()->getPIUID();
+            echo "<p>Ownership of PI Account/Group: <code>$group_uid</code> </p>";
         } else {
             $owner_uid = UnityGroup::getUIDfromPIUID($pi_uid);
-            echo "<p>Joining existing group owned by " . $owner_uid . "</p>";
-            echo "<p>You will receive an email when your account has been approved by the PI.";
-            echo "You may need to remind them.</p>";
+            echo "<p>Membership in PI Group owned by: <code>$owner_uid</code></p>";
         }
         ?>
-        <a href="?cancel=true">Cancel Request</a>
+        </li></ul>
+        <hr>
+        <p><strong>Requesting Ownership of PI Account/Group</strong></p>
+        <p>You will receive an email when your account has been approved.</p>
+        <p>Email <a href="mailto:<?php echo $CONFIG['mail']['support']; ?>"><?php echo $CONFIG['mail']['support_name']; ?></a> if you have not heard back in one business day. </p>
+        <br>
+        <p><strong>Requesting Membership in a PI Group</strong></p>
+        <p>You will receive an email when your account has been approved by the PI.</p>
+        <p>You may need to remind them.</p>
+        <hr>
+        <form action="" method="POST">
+            <input name="cancel" style='margin-top: 10px;' type='submit' value='Cancel Request'/>
+        </form>
     <?php endforeach; ?>
 <?php else : ?>
     <form id="newAccountForm" action="" method="POST">


### PR DESCRIPTION
* move `require $LOC_HEADER` below `$POST` handling so that `UnitySite::badRequest` is able to send status header (can't send headers after sending content)
* made `UnitiySQL::REQUEST_BECOME_PI` public, made `new_account.php` refrence that const rather than `"admin"`
* replaced `errors` with `UnitySite::badRequest`
* moved `cancel` functionality from `GET` to `POST`, modified `POST` handling since there are multiple types of posts now
* restructured page

before:

https://github.com/user-attachments/assets/896a8dfb-5288-4ba4-ba64-764de1027129

after:

https://github.com/user-attachments/assets/1c20a3a3-2702-4383-b4c3-8208e86627c8