### PR TITLE
Store user data in request

### DIFF
--- a/resources/lib/UnityGroup.php
+++ b/resources/lib/UnityGroup.php
@@ -139,8 +139,7 @@ class UnityGroup
     public function approveGroup($operator = null, $send_mail = true)
     {
         $uid = $this->getOwner()->getUID();
-        $gid = $this->getPIUID();
-        $request = $this->SQL->getRequest($uid, $gid);
+        $request = $this->SQL->getRequest($uid, UnitySQL::REQUEST_BECOME_PI);
         if (is_null($request)) {
             throw new Exception("uid '$uid' does not have a group request!");
         }

--- a/resources/lib/UnityGroup.php
+++ b/resources/lib/UnityGroup.php
@@ -93,7 +93,7 @@ class UnityGroup
         if ($send_mail) {
             // send email to requestor
             $this->MAILER->sendMail(
-                $this->getOwner()->getMail(),
+                $email,
                 "group_request"
             );
 
@@ -180,7 +180,7 @@ class UnityGroup
         // send email to the newly approved PI
         if ($send_mail) {
             $this->MAILER->sendMail(
-                $this->getOwner()->getMail(),
+                $request["email"],
                 "group_created"
             );
         }

--- a/resources/lib/UnityGroup.php
+++ b/resources/lib/UnityGroup.php
@@ -315,7 +315,6 @@ class UnityGroup
         // add user to the LDAP object
         $this->addUserToGroup($new_user);
 
-        // remove request, this will fail silently if the request doesn't exist
         $this->SQL->removeRequest($new_user->getUID(), $this->pi_uid);
 
         // send email to the requestor

--- a/resources/lib/UnityGroup.php
+++ b/resources/lib/UnityGroup.php
@@ -140,14 +140,6 @@ class UnityGroup
     {
         $uid = $this->getOwner()->getUID();
         $request = $this->SQL->getRequest($uid, UnitySQL::REQUEST_BECOME_PI);
-        if (is_null($request)) {
-            throw new Exception("uid '$uid' does not have a group request!");
-        }
-        if (!$this->SQL->requestExists($this->getOwner()->getUID())) {
-            throw new Exception(
-                "attempt to approve nonexistent request for group='{$this->getPIUID()}'"
-            );
-        }
 
         // check for edge cases...
         if ($this->exists()) {
@@ -299,14 +291,9 @@ class UnityGroup
      */
     public function approveUser($new_user, $send_mail = true)
     {
-
         $uid = $new_user->getUID();
         $gid = $this->getPIUID();
         $request = $this->SQL->getRequest($uid, $gid);
-        if (is_null($request)) {
-            throw new Exception("uid '$uid' does not have a request for group '$gid'!");
-        }
-
         // check if user exists
         if (!$new_user->exists()) {
             $new_user->init(
@@ -350,9 +337,6 @@ class UnityGroup
         $uid = $new_user->getUID();
         $gid = $this->getPIUID();
         $request = $this->SQL->getRequest($uid, $gid);
-        if (is_null($request)) {
-            throw new Exception("uid '$uid' does not have a request for group '$gid'!");
-        }
 
         // remove request, this will fail silently if the request doesn't exist
         $this->SQL->removeRequest($new_user->getUID(), $this->pi_uid);

--- a/resources/lib/UnityGroup.php
+++ b/resources/lib/UnityGroup.php
@@ -76,7 +76,7 @@ class UnityGroup
     // Portal-facing methods, these are the methods called by scripts in webroot
     //
 
-    public function requestGroup($send_mail_to_admins, $send_mail = true)
+    public function requestGroup($firstname, $lastname, $email, $org, $send_mail_to_admins, $send_mail = true)
     {
         // check for edge cases...
         if ($this->exists()) {
@@ -88,7 +88,7 @@ class UnityGroup
             return;
         }
 
-        $this->SQL->addRequest($this->getOwner()->getUID());
+        $this->SQL->addRequest($this->getOwner()->getUID(), $firstname, $lastname, $email, $org);
 
         if ($send_mail) {
             // send email to requestor
@@ -101,9 +101,9 @@ class UnityGroup
                 "group_request_admin",
                 array(
                     "user" => $this->getOwner()->getUID(),
-                    "org" => $this->getOwner()->getOrg(),
-                    "name" => $this->getOwner()->getFullname(),
-                    "email" => $this->getOwner()->getMail()
+                    "org" => $org,
+                    "name" => "$firstname $lastname",
+                    "email" => $email
                 )
             );
 
@@ -113,9 +113,9 @@ class UnityGroup
                     "group_request_admin",
                     array(
                         "user" => $this->getOwner()->getUID(),
-                        "org" => $this->getOwner()->getOrg(),
-                        "name" => $this->getOwner()->getFullname(),
-                        "email" => $this->getOwner()->getMail()
+                        "org" => $org,
+                        "name" => "$firstname $lastname",
+                        "email" => $email
                     )
                 );
             }
@@ -125,9 +125,9 @@ class UnityGroup
                 "group_request_admin",
                 array(
                     "user" => $this->getOwner()->getUID(),
-                    "org" => $this->getOwner()->getOrg(),
-                    "name" => $this->getOwner()->getFullname(),
-                    "email" => $this->getOwner()->getMail()
+                    "org" => $org,
+                    "name" => "$firstname $lastname",
+                    "email" => $email
                 )
             );
         }
@@ -138,10 +138,11 @@ class UnityGroup
      */
     public function approveGroup($operator = null, $send_mail = true)
     {
-        if (!$this->SQL->requestExists($this->getOwner()->getUID())) {
-            throw new Exception(
-                "attempt to approve nonexistent request for group='{$this->getPIUID()}' uid='$new_user'"
-            );
+        $uid = $this->getOwner()->getUID();
+        $gid = $this->getPIUID();
+        $request = $this->SQL->getRequest($uid, $gid);
+        if (is_null($request)) {
+            throw new Exception("uid '$uid' does not have a group request!");
         }
 
         // check for edge cases...
@@ -151,7 +152,13 @@ class UnityGroup
 
         // check if owner exists
         if (!$this->getOwner()->exists()) {
-            $this->getOwner()->init();
+            $this->getOwner()->init(
+                $request["firstname"],
+                $request["lastname"],
+                $request["email"],
+                $request["org"],
+                $send_mail
+            );
         }
 
         // initialize ldap objects, if this fails the script will crash, but nothing will persistently break
@@ -288,15 +295,22 @@ class UnityGroup
      */
     public function approveUser($new_user, $send_mail = true)
     {
-        if (!$this->requestExists($new_user)) {
-            throw new Exception(
-                "attempt to approve nonexistent request for group='{$this->getPIUID()}' uid='$new_user'"
-            );
+
+        $uid = $new_user->getUID();
+        $gid = $this->getPIUID();
+        $request = $this->SQL->getRequest($uid, $gid);
+        if (is_null($request)) {
+            throw new Exception("uid '$uid' does not have a request for group '$gid'!");
         }
 
         // check if user exists
         if (!$new_user->exists()) {
-            $new_user->init();
+            $new_user->init(
+                $request["firstname"],
+                $request["lastname"],
+                $request["email"],
+                $request["org"],
+            );
         }
 
         // add user to the LDAP object
@@ -320,9 +334,9 @@ class UnityGroup
                 array(
                     "group" => $this->pi_uid,
                     "user" => $new_user->getUID(),
-                    "name" => $new_user->getFullName(),
-                    "email" => $new_user->getMail(),
-                    "org" => $new_user->getOrg()
+                    "name" => $request["firstname"] . " " . $request["lastname"],
+                    "email" => $request["email"],
+                    "org" => $request["org"],
                     )
             );
         }
@@ -330,8 +344,11 @@ class UnityGroup
 
     public function denyUser($new_user, $send_mail = true)
     {
-        if (!$this->requestExists($new_user)) {
-            return;
+        $uid = $new_user->getUID();
+        $gid = $this->getPIUID();
+        $request = $this->SQL->getRequest($uid, $gid);
+        if (is_null($request)) {
+            throw new Exception("uid '$uid' does not have a request for group '$gid'!");
         }
 
         // remove request, this will fail silently if the request doesn't exist
@@ -396,7 +413,7 @@ class UnityGroup
         }
     }
 
-    public function newUserRequest($new_user, $send_mail = true)
+    public function newUserRequest($new_user, $firstname, $lastname, $email, $org, $send_mail = true)
     {
         if ($this->userExists($new_user)) {
             UnitySite::errorLog("warning", "user '$new_user' already in group");
@@ -413,7 +430,7 @@ class UnityGroup
             return;
         }
 
-        $this->addRequest($new_user->getUID());
+        $this->addRequest($new_user->getUID(), $firstname, $lastname, $email, $org);
 
         if ($send_mail) {
             // send email to user
@@ -430,9 +447,9 @@ class UnityGroup
                 array(
                     "group" => $this->pi_uid,
                     "user" => $new_user->getUID(),
-                    "name" => $new_user->getFullName(),
-                    "email" => $new_user->getMail(),
-                    "org" => $new_user->getOrg()
+                    "name" => "$firstname $lastname",
+                    "email" => $email,
+                    "org" => $org,
                     )
             );
         }
@@ -452,7 +469,17 @@ class UnityGroup
                 $this->REDIS,
                 $this->WEBHOOK
             );
-            array_push($out, [$user, $request["timestamp"]]);
+            array_push(
+                $out,
+                [
+                    $user,
+                    $request["timestamp"],
+                    $request["firstname"],
+                    $request["lastname"],
+                    $request["email"],
+                    $request["org"],
+                ]
+            );
         }
 
         return $out;
@@ -563,9 +590,9 @@ class UnityGroup
         return in_array($user->getUID(), $this->getGroupMemberUIDs());
     }
 
-    private function addRequest($uid)
+    private function addRequest($uid, $firstname, $lastname, $email, $org)
     {
-        $this->SQL->addRequest($uid, $this->pi_uid);
+        $this->SQL->addRequest($uid, $firstname, $lastname, $email, $org, $this->pi_uid);
     }
 
     //

--- a/resources/lib/UnityGroup.php
+++ b/resources/lib/UnityGroup.php
@@ -434,7 +434,7 @@ class UnityGroup
         if ($send_mail) {
             // send email to user
             $this->MAILER->sendMail(
-                $new_user->getMail(),
+                $email,
                 "group_user_request",
                 array("group" => $this->pi_uid)
             );

--- a/resources/lib/UnityGroup.php
+++ b/resources/lib/UnityGroup.php
@@ -138,10 +138,10 @@ class UnityGroup
      */
     public function approveGroup($operator = null, $send_mail = true)
     {
-        $uid = $this->getOwner()->getUID();
-        $request = $this->SQL->getRequest($uid, UnitySQL::REQUEST_BECOME_PI);
-        if (is_null($request)) {
-            throw new Exception("uid '$uid' does not have a group request!");
+        if (!$this->SQL->requestExists($this->getOwner()->getUID())) {
+            throw new Exception(
+                "attempt to approve nonexistent request for group='{$this->getPIUID()}'"
+            );
         }
 
         // check for edge cases...
@@ -294,12 +294,10 @@ class UnityGroup
      */
     public function approveUser($new_user, $send_mail = true)
     {
-
-        $uid = $new_user->getUID();
-        $gid = $this->getPIUID();
-        $request = $this->SQL->getRequest($uid, $gid);
-        if (is_null($request)) {
-            throw new Exception("uid '$uid' does not have a request for group '$gid'!");
+        if (!$this->requestExists($new_user)) {
+            throw new Exception(
+                "attempt to approve nonexistent request for group='{$this->getPIUID()}' uid='$new_user'"
+            );
         }
 
         // check if user exists
@@ -342,11 +340,10 @@ class UnityGroup
 
     public function denyUser($new_user, $send_mail = true)
     {
-        $uid = $new_user->getUID();
-        $gid = $this->getPIUID();
-        $request = $this->SQL->getRequest($uid, $gid);
-        if (is_null($request)) {
-            throw new Exception("uid '$uid' does not have a request for group '$gid'!");
+        if (!$this->requestExists($new_user)) {
+            throw new Exception(
+                "attempt to deny nonexistent request for group='{$this->getPIUID()}' uid='$new_user'"
+            );
         }
 
         // remove request, this will fail silently if the request doesn't exist

--- a/resources/lib/UnityGroup.php
+++ b/resources/lib/UnityGroup.php
@@ -138,10 +138,10 @@ class UnityGroup
      */
     public function approveGroup($operator = null, $send_mail = true)
     {
-        if (!$this->SQL->requestExists($this->getOwner()->getUID())) {
-            throw new Exception(
-                "attempt to approve nonexistent request for group='{$this->getPIUID()}'"
-            );
+        $uid = $this->getOwner()->getUID();
+        $request = $this->SQL->getRequest($uid, UnitySQL::REQUEST_BECOME_PI);
+        if (is_null($request)) {
+            throw new Exception("uid '$uid' does not have a group request!");
         }
 
         // check for edge cases...
@@ -294,10 +294,12 @@ class UnityGroup
      */
     public function approveUser($new_user, $send_mail = true)
     {
-        if (!$this->requestExists($new_user)) {
-            throw new Exception(
-                "attempt to approve nonexistent request for group='{$this->getPIUID()}' uid='$new_user'"
-            );
+
+        $uid = $new_user->getUID();
+        $gid = $this->getPIUID();
+        $request = $this->SQL->getRequest($uid, $gid);
+        if (is_null($request)) {
+            throw new Exception("uid '$uid' does not have a request for group '$gid'!");
         }
 
         // check if user exists
@@ -340,10 +342,11 @@ class UnityGroup
 
     public function denyUser($new_user, $send_mail = true)
     {
-        if (!$this->requestExists($new_user)) {
-            throw new Exception(
-                "attempt to deny nonexistent request for group='{$this->getPIUID()}' uid='$new_user'"
-            );
+        $uid = $new_user->getUID();
+        $gid = $this->getPIUID();
+        $request = $this->SQL->getRequest($uid, $gid);
+        if (is_null($request)) {
+            throw new Exception("uid '$uid' does not have a request for group '$gid'!");
         }
 
         // remove request, this will fail silently if the request doesn't exist

--- a/resources/lib/UnityOrg.php
+++ b/resources/lib/UnityOrg.php
@@ -55,11 +55,9 @@ class UnityOrg
         return $this->orgid;
     }
 
-    public function inOrg($user)
+    public function inOrg($user, $ignorecache = false)
     {
-        $org_group = $this->getLDAPOrgGroup();
-        $members = $org_group->getAttribute("memberuid");
-        return in_array($user, $members);
+        return in_array($user->getUID(), $this->getOrgMemberUIDs($ignorecache));
     }
 
     public function getOrgMembers($ignorecache = false)

--- a/resources/lib/UnitySQL.php
+++ b/resources/lib/UnitySQL.php
@@ -38,17 +38,23 @@ class UnitySQL
     //
     // requests table methods
     //
-    public function addRequest($requestor, $dest = self::REQUEST_BECOME_PI)
+    public function addRequest($requestor, $firstname, $lastname, $email, $org, $dest = self::REQUEST_BECOME_PI)
     {
         if ($this->requestExists($requestor, $dest)) {
             return;
         }
 
         $stmt = $this->conn->prepare(
-            "INSERT INTO " . self::TABLE_REQS . " (uid, request_for) VALUES (:uid, :request_for)"
+            "INSERT INTO " . self::TABLE_REQS . " " .
+            "(uid, firstname, lastname, email, org, request_for) VALUES " .
+            "(:uid, :firstname, :lastname, :email, :org, :request_for)"
         );
         $stmt->bindParam(":uid", $requestor);
         $stmt->bindParam(":request_for", $dest);
+        $stmt->bindParam(":firstname", $firstname);
+        $stmt->bindParam(":lastname", $lastname);
+        $stmt->bindParam(":email", $email);
+        $stmt->bindParam(":org", $org);
 
         $stmt->execute();
     }
@@ -78,17 +84,27 @@ class UnitySQL
         $stmt->execute();
     }
 
-    public function requestExists($requestor, $dest = self::REQUEST_BECOME_PI)
+    public function getRequest($user, $dest)
     {
         $stmt = $this->conn->prepare(
             "SELECT * FROM " . self::TABLE_REQS . " WHERE uid=:uid and request_for=:request_for"
         );
-        $stmt->bindParam(":uid", $requestor);
+        $stmt->bindParam(":uid", $user);
         $stmt->bindParam(":request_for", $dest);
-
         $stmt->execute();
+        $result = $stmt->fetchAll();
+        if (count($result) == 0) {
+            throw new Exception("no such request: uid='$user' request_for='$dest'");
+        }
+        if (count($result) > 1) {
+            throw new Exception("too many requests for uid='$user' request_for='$dest'");
+        }
+        return $result[0];
+    }
 
-        return count($stmt->fetchAll()) > 0;
+    public function requestExists($requestor, $dest = self::REQUEST_BECOME_PI)
+    {
+        return (!is_null(self::getRequest($requestor, $dest)));
     }
 
     public function getRequests($dest = self::REQUEST_BECOME_PI)

--- a/resources/lib/UnitySQL.php
+++ b/resources/lib/UnitySQL.php
@@ -104,7 +104,13 @@ class UnitySQL
 
     public function requestExists($requestor, $dest = self::REQUEST_BECOME_PI)
     {
-        return (!is_null(self::getRequest($requestor, $dest)));
+        try {
+            $this->getRequest($requestor, $dest);
+            return true;
+        // FIXME use a specific exception
+        } catch (\Exception) {
+            return false;
+        }
     }
 
     public function getRequests($dest = self::REQUEST_BECOME_PI)

--- a/resources/lib/UnitySQL.php
+++ b/resources/lib/UnitySQL.php
@@ -97,7 +97,7 @@ class UnitySQL
             throw new Exception("no such request: uid='$user' request_for='$dest'");
         }
         if (count($result) > 1) {
-            throw new Exception("too many requests for uid='$user' request_for='$dest'");
+            throw new Exception("multiple requests for uid='$user' request_for='$dest'");
         }
         return $result[0];
     }

--- a/resources/lib/UnitySQL.php
+++ b/resources/lib/UnitySQL.php
@@ -94,10 +94,10 @@ class UnitySQL
         $stmt->execute();
         $result = $stmt->fetchAll();
         if (count($result) == 0) {
-            throw new Exception("no such request: uid='$user' request_for='$dest'");
+            throw new \Exception("no such request: uid='$user' request_for='$dest'");
         }
         if (count($result) > 1) {
-            throw new Exception("multiple requests for uid='$user' request_for='$dest'");
+            throw new \Exception("multiple requests for uid='$user' request_for='$dest'");
         }
         return $result[0];
     }

--- a/resources/lib/UnityUser.php
+++ b/resources/lib/UnityUser.php
@@ -102,14 +102,14 @@ class UnityUser
         //
         // add to org group
         //
-        $orgEntry = $this->getOrgGroup();
+        $org = $this->getOrgGroup();
         // create organization if it doesn't exist
-        if (!$orgEntry->exists()) {
-            $orgEntry->init();
+        if (!$org->exists()) {
+            $org->init();
         }
 
-        if (!$orgEntry->inOrg($this)) {
-            $orgEntry->addUser($this);
+        if (!$org->inOrg($this)) {
+            $org->addUser($this);
         }
 
         // add to user group as well as user OU

--- a/resources/lib/UnityUser.php
+++ b/resources/lib/UnityUser.php
@@ -49,10 +49,11 @@ class UnityUser
      * @param string $firstname First name of new account
      * @param string $lastname Last name of new account
      * @param string $email email of new account
+     * @param string $org organization name of new account
      * @param bool $isPI boolean value for if the user checked the "I am a PI box"
      * @return void
      */
-    public function init($send_mail = true)
+    public function init($firstname, $lastname, $email, $org, $send_mail = true)
     {
         //
         // Create LDAP group
@@ -74,14 +75,14 @@ class UnityUser
         if (!$ldapUserEntry->exists()) {
             $ldapUserEntry->setAttribute("objectclass", UnityLDAP::POSIX_ACCOUNT_CLASS);
             $ldapUserEntry->setAttribute("uid", $this->uid);
-            $ldapUserEntry->setAttribute("givenname", $this->getFirstname());
-            $ldapUserEntry->setAttribute("sn", $this->getLastname());
+            $ldapUserEntry->setAttribute("givenname", $firstname);
+            $ldapUserEntry->setAttribute("sn", $lastname);
             $ldapUserEntry->setAttribute(
                 "gecos",
                 \transliterator_transliterate("Latin-ASCII", "{$this->getFirstname()} {$this->getLastname()}")
             );
-            $ldapUserEntry->setAttribute("mail", $this->getMail());
-            $ldapUserEntry->setAttribute("o", $this->getOrg());
+            $ldapUserEntry->setAttribute("mail", $email);
+            $ldapUserEntry->setAttribute("o", $org);
             $ldapUserEntry->setAttribute("homedirectory", self::HOME_DIR . $this->uid);
             $ldapUserEntry->setAttribute("loginshell", $this->LDAP->getDefUserShell());
             $ldapUserEntry->setAttribute("uidnumber", strval($id));
@@ -90,10 +91,10 @@ class UnityUser
         }
 
         // update cache
-        //$this->REDIS->setCache($this->uid, "firstname", $this->getFirstname());
-        //$this->REDIS->setCache($this->uid, "lastname", $this->getLastname());
-        //$this->REDIS->setCache($this->uid, "mail", $this->getMail());
-        //$this->REDIS->setCache($this->uid, "org", $this->getOrg());
+        $this->REDIS->setCache($this->uid, "firstname", $firstname);
+        $this->REDIS->setCache($this->uid, "lastname", $lastname);
+        $this->REDIS->setCache($this->uid, "mail", $email);
+        $this->REDIS->setCache($this->uid, "org", $org);
         $this->REDIS->setCache($this->uid, "homedir", self::HOME_DIR . $this->uid);
         $this->REDIS->setCache($this->uid, "loginshell", $this->LDAP->getDefUserShell());
         $this->REDIS->setCache($this->uid, "sshkeys", array());

--- a/resources/lib/UnityUser.php
+++ b/resources/lib/UnityUser.php
@@ -176,7 +176,6 @@ class UnityUser
      */
     public function getUID()
     {
-        assert($this->exists());
         return $this->uid;
     }
 

--- a/resources/lib/UnityUser.php
+++ b/resources/lib/UnityUser.php
@@ -79,7 +79,7 @@ class UnityUser
             $ldapUserEntry->setAttribute("sn", $lastname);
             $ldapUserEntry->setAttribute(
                 "gecos",
-                \transliterator_transliterate("Latin-ASCII", "{$this->getFirstname()} {$this->getLastname()}")
+                \transliterator_transliterate("Latin-ASCII", "$firstname $lastname")
             );
             $ldapUserEntry->setAttribute("mail", $email);
             $ldapUserEntry->setAttribute("o", $org);

--- a/resources/lib/UnityUser.php
+++ b/resources/lib/UnityUser.php
@@ -176,6 +176,7 @@ class UnityUser
      */
     public function getUID()
     {
+        assert($this->exists());
         return $this->uid;
     }
 
@@ -189,6 +190,7 @@ class UnityUser
 
     public function getOrg($ignorecache = false)
     {
+        assert($this->exists());
         if (!$ignorecache) {
             $cached_val = $this->REDIS->getCache($this->getUID(), "org");
             if (!is_null($cached_val)) {
@@ -238,6 +240,7 @@ class UnityUser
      */
     public function getFirstname($ignorecache = false)
     {
+        assert($this->exists());
         if (!$ignorecache) {
             $cached_val = $this->REDIS->getCache($this->getUID(), "firstname");
             if (!is_null($cached_val)) {
@@ -287,6 +290,7 @@ class UnityUser
      */
     public function getLastname($ignorecache = false)
     {
+        assert($this->exists());
         if (!$ignorecache) {
             $cached_val = $this->REDIS->getCache($this->getUID(), "lastname");
             if (!is_null($cached_val)) {
@@ -309,6 +313,7 @@ class UnityUser
 
     public function getFullname()
     {
+        assert($this->exists());
         return $this->getFirstname() . " " . $this->getLastname();
     }
 
@@ -341,6 +346,7 @@ class UnityUser
      */
     public function getMail($ignorecache = false)
     {
+        assert($this->exists());
         if (!$ignorecache) {
             $cached_val = $this->REDIS->getCache($this->getUID(), "mail");
             if (!is_null($cached_val)) {
@@ -404,6 +410,7 @@ class UnityUser
      */
     public function getSSHKeys($ignorecache = false)
     {
+        assert($this->exists());
         if (!$ignorecache) {
             $cached_val = $this->REDIS->getCache($this->getUID(), "sshkeys");
             if (!is_null($cached_val)) {
@@ -480,6 +487,7 @@ class UnityUser
      */
     public function getLoginShell($ignorecache = false)
     {
+        assert($this->exists());
         if (!$ignorecache) {
             $cached_val = $this->REDIS->getCache($this->getUID(), "loginshell");
             if (!is_null($cached_val)) {
@@ -528,6 +536,7 @@ class UnityUser
      */
     public function getHomeDir($ignorecache = false)
     {
+        assert($this->exists());
         if (!$ignorecache) {
             $cached_val = $this->REDIS->getCache($this->getUID(), "homedir");
             if (!is_null($cached_val)) {

--- a/resources/lib/UnityUser.php
+++ b/resources/lib/UnityUser.php
@@ -108,7 +108,7 @@ class UnityUser
             $orgEntry->init();
         }
 
-        if (!$orgEntry->inOrg($this->uid)) {
+        if (!$orgEntry->inOrg($this)) {
             $orgEntry->addUser($this);
         }
 

--- a/test/functional/NewUserTest.php
+++ b/test/functional/NewUserTest.php
@@ -159,9 +159,9 @@ class NewUserTest extends TestCase
             $this->assertRequestedMembership(false, $gid);
             $this->assertTrue(!$pi_group->requestExists($USER));
         } finally {
+            $this->ensureOrgGroupDoesNotExist();
             $this->ensureUserNotInPIGroup($pi_group);
             $this->ensureUserDoesNotExist();
-            $this->ensureOrgGroupDoesNotExist();
         }
     }
 
@@ -208,9 +208,9 @@ class NewUserTest extends TestCase
             // $this->assertTrue($third_request_failed);
             $this->assertRequestedPIGroup(false);
         } finally {
+            $this->ensureOrgGroupDoesNotExist();
             $this->ensurePIGroupDoesNotExist();
             $this->ensureUserDoesNotExist();
-            $this->ensureOrgGroupDoesNotExist();
         }
     }
 }

--- a/test/functional/NewUserTest.php
+++ b/test/functional/NewUserTest.php
@@ -142,6 +142,8 @@ class NewUserTest extends TestCase
             $this->assertTrue($pi_group->requestExists($USER));
             $this->assertRequestedMembership(true, $gid);
 
+            $REDIS->flushAll(); // regression test: flush used to break requests
+
             $pi_group->approveUser($USER);
             $this->assertTrue(!$pi_group->requestExists($USER));
             $this->assertRequestedMembership(false, $gid);
@@ -192,6 +194,8 @@ class NewUserTest extends TestCase
 
             $this->requestGroupCreation();
             $this->assertRequestedPIGroup(true);
+
+            $REDIS->flushAll(); // regression test: flush used to break requests
 
             $pi_group->approveGroup();
             $this->assertRequestedPIGroup(false);

--- a/test/functional/NewUserTest.php
+++ b/test/functional/NewUserTest.php
@@ -3,13 +3,18 @@
 use PHPUnit\Framework\TestCase;
 use UnityWebPortal\lib\exceptions\PhpUnitNoDieException;
 use UnityWebPortal\lib\UnityGroup;
+use UnityWebPortal\lib\UnityOrg;
+use UnityWebPortal\lib\UnitySQL;
 
 class NewUserTest extends TestCase
 {
-    private function assertNumberGroupRequests(int $x)
+    private function assertRequestedPIGroup(bool $expected)
     {
         global $USER, $SQL;
-        $this->assertEquals($x, count($SQL->getRequestsByUser($USER->getUID())));
+        $this->assertEquals(
+            $expected,
+            $SQL->requestExists($USER->getUID(), UnitySQL::REQUEST_BECOME_PI)
+        );
     }
 
     private function requestGroupCreation()
@@ -45,12 +50,12 @@ class NewUserTest extends TestCase
     {
         global $USER, $SQL, $LDAP;
         $SQL->deleteRequestsByUser($USER->getUID());
-        $org = $USER->getOrgGroup();
-        if ($org->inOrg($USER)) {
-            $org->removeUser($USER);
-            assert(!$org->inOrg($USER));
-        }
         if ($USER->exists()) {
+            $org = $USER->getOrgGroup();
+            if ($org->exists() and $org->inOrg($USER)) {
+                $org->removeUser($USER);
+                assert(!$org->inOrg($USER));
+            }
             $USER->getLDAPUser()->delete();
             assert(!$USER->exists());
         }
@@ -69,8 +74,8 @@ class NewUserTest extends TestCase
 
     private function ensureOrgGroupDoesNotExist()
     {
-        global $USER;
-        $org_group = $USER->getOrgGroup();
+        global $USER, $SSO, $LDAP, $SQL, $MAILER, $REDIS, $WEBHOOK;
+        $org_group = new UnityOrg($SSO["org"], $LDAP, $SQL, $MAILER, $REDIS, $WEBHOOK);
         if ($org_group->exists()) {
             $org_group->getLDAPOrgGroup()->delete();
             assert(!$org_group->exists());
@@ -97,18 +102,19 @@ class NewUserTest extends TestCase
 
     public function testCreateUserByJoinGoup()
     {
-        global $USER, $SQL, $LDAP;
+        global $USER, $SSO, $LDAP, $SQL, $MAILER, $REDIS, $WEBHOOK;
         switchUser(...getUserIsPIHasNoMembersNoMemberRequests());
         $pi_group = $USER->getPIGroup();
         switchUser(...getNonExistentUser());
         $this->assertTrue(!$USER->exists());
-        $this->assertTrue(!$USER->getOrgGroup()->exists());
+        $newOrg = new UnityOrg($SSO["org"], $LDAP, $SQL, $MAILER, $REDIS, $WEBHOOK);
+        $this->assertTrue(!$newOrg->exists());
         $this->assertTrue($pi_group->exists());
         $this->assertTrue(!$pi_group->userExists($USER));
-        $this->assertNumberGroupRequests(0);
+        $this->assertRequestedPIGroup(false);
         try {
             $this->requestGroupMembership($pi_group->getPIUID());
-            $this->assertNumberGroupRequests(1);
+            $this->assertRequestedPIGroup(true);
 
             // $second_request_failed = false;
             // try {
@@ -117,21 +123,21 @@ class NewUserTest extends TestCase
             //     $second_request_failed = true;
             // }
             // $this->assertTrue($second_request_failed);
-            $this->assertNumberGroupRequests(1);
+            $this->assertRequestedPIGroup(true);
 
             $this->cancelAllRequests();
-            $this->assertNumberGroupRequests(0);
+            $this->assertRequestedPIGroup(false);
 
             $this->requestGroupMembership($pi_group->getPIUID());
             $this->assertTrue($pi_group->requestExists($USER));
-            $this->assertNumberGroupRequests(1);
+            $this->assertRequestedPIGroup(true);
 
             $pi_group->approveUser($USER);
             $this->assertTrue(!$pi_group->requestExists($USER));
-            $this->assertNumberGroupRequests(0);
+            $this->assertRequestedPIGroup(false);
             $this->assertTrue($pi_group->userExists($USER));
             $this->assertTrue($USER->exists());
-            $this->assertTrue($USER->getOrgGroup()->exists());
+            $this->assertTrue($newOrg->exists());
 
             // $third_request_failed = false;
             // try {
@@ -140,7 +146,7 @@ class NewUserTest extends TestCase
             //     $third_request_failed = true;
             // }
             // $this->assertTrue($third_request_failed);
-            $this->assertNumberGroupRequests(0);
+            $this->assertRequestedPIGroup(false);
             $this->assertTrue(!$pi_group->requestExists($USER));
         } finally {
             $this->ensureUserNotInPIGroup($pi_group);
@@ -151,15 +157,16 @@ class NewUserTest extends TestCase
 
     public function testCreateUserByCreateGroup()
     {
-        global $USER, $SQL, $LDAP;
+        global $USER, $SSO, $LDAP, $SQL, $MAILER, $REDIS, $WEBHOOK;
         switchuser(...getNonExistentUser());
         $pi_group = $USER->getPIGroup();
         $this->assertTrue(!$USER->exists());
         $this->assertTrue(!$pi_group->exists());
-        $this->assertTrue(!$USER->getOrgGroup()->exists());
+        $newOrg = new UnityOrg($SSO["org"], $LDAP, $SQL, $MAILER, $REDIS, $WEBHOOK);
+        $this->assertTrue(!$newOrg->exists());
         try {
             $this->requestGroupCreation();
-            $this->assertNumberGroupRequests(1);
+            $this->assertRequestedPIGroup(true);
 
             // $second_request_failed = false;
             // try {
@@ -168,19 +175,19 @@ class NewUserTest extends TestCase
             //     $second_request_failed = true;
             // }
             // $this->assertTrue($second_request_failed);
-            $this->assertNumberGroupRequests(1);
+            $this->assertRequestedPIGroup(true);
 
             $this->cancelAllRequests();
-            $this->assertNumberGroupRequests(0);
+            $this->assertRequestedPIGroup(false);
 
             $this->requestGroupCreation();
-            $this->assertNumberGroupRequests(1);
+            $this->assertRequestedPIGroup(true);
 
             $pi_group->approveGroup();
-            $this->assertNumberGroupRequests(0);
+            $this->assertRequestedPIGroup(false);
             $this->assertTrue($pi_group->exists());
             $this->assertTrue($USER->exists());
-            $this->assertTrue($USER->getOrgGroup()->exists());
+            $this->assertTrue($newOrg->exists());
 
             // $third_request_failed = false;
             // try {
@@ -189,7 +196,7 @@ class NewUserTest extends TestCase
             //     $third_request_failed = true;
             // }
             // $this->assertTrue($third_request_failed);
-            $this->assertNumberGroupRequests(0);
+            $this->assertRequestedPIGroup(false);
         } finally {
             $this->ensurePIGroupDoesNotExist();
             $this->ensureUserDoesNotExist();

--- a/test/functional/PiBecomeRequestTest.php
+++ b/test/functional/PiBecomeRequestTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use PHPUnit\Framework\TestCase;
+use UnityWebPortal\lib\UnitySQL;
 
 class PiBecomeRequestTest extends TestCase
 {
@@ -49,7 +50,9 @@ class PiBecomeRequestTest extends TestCase
             );
             $this->assertNumberPiBecomeRequests(1);
         } finally {
-            $SQL->removeRequest($USER->getUID());
+            if ($SQL->requestExists($USER, UnitySQL::REQUEST_BECOME_PI)) {
+                $SQL->removeRequest($USER->getUID(), UnitySQL::REQUEST_BECOME_PI);
+            }
         }
     }
 
@@ -67,7 +70,9 @@ class PiBecomeRequestTest extends TestCase
             );
             $this->assertNumberPiBecomeRequests(0);
         } finally {
-            $SQL->removeRequest($USER->getUID());
+            if ($SQL->requestExists($USER, UnitySQL::REQUEST_BECOME_PI)) {
+                $SQL->removeRequest($USER->getUID(), UnitySQL::REQUEST_BECOME_PI);
+            }
         }
     }
 }

--- a/test/functional/PiMemberApproveTest.php
+++ b/test/functional/PiMemberApproveTest.php
@@ -23,7 +23,7 @@ class PiMemberApproveTest extends TestCase {
     {
         http_post(
             __DIR__ . "/../../webroot/panel/pi.php",
-            ["form_type" => "userReq", "action" => "approve", "uid" => $uid]
+            ["form_type" => "userReq", "action" => "Approve", "uid" => $uid]
         );
     }
 
@@ -67,6 +67,7 @@ class PiMemberApproveTest extends TestCase {
 
             switchUser(...$piSwitchArgs);
             $this->approveUser($uid);
+            $this->assertTrue(!$piGroup->requestExists($user));
             $this->assertEmpty($piGroup->getRequests());
             $this->assertGroupMembers($piGroup, [$piUID, $uid]);
             $this->assertTrue($piGroup->userExists($user));

--- a/test/functional/PiMemberApproveTest.php
+++ b/test/functional/PiMemberApproveTest.php
@@ -3,87 +3,104 @@
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use UnityWebPortal\lib\UnityUser;
+use UnityWebPortal\lib\UnityGroup;
+use UnityWebPortal\lib\UnitySSO;
 
 class PiMemberApproveTest extends TestCase {
-    static $requestUid;
-    static $noRequestUid;
-
-    public static function setUpBeforeClass(): void{
-        global $USER;
-        switchUser(...getNormalUser());
-        self::$requestUid = $USER->getUID();
-        switchUser(...getNormalUser2());
-        self::$noRequestUid = $USER->getUID();
-    }
+        static $userWithRequestSwitchArgs;
+        static $userWithoutRequestSwitchArgs;
+        static $piSwitchArgs;
+        static $pi;
+        static $userWithRequestUID;
+        static $userWithoutRequestUID;
+        static $piUID;
+        static $userWithRequest;
+        static $userWithoutRequest;
+        static $piGroup;
+        static $piGroupGID;
 
     private function approveUser(string $uid)
     {
-        post(
+        http_post(
             __DIR__ . "/../../webroot/panel/pi.php",
             ["form_type" => "userReq", "action" => "approve", "uid" => $uid]
         );
     }
 
-    public function testApproveRequest()
+    private function requestJoinPI(string $gid)
     {
-        global $USER, $LDAP, $SQL, $MAILER, $REDIS, $WEBHOOK;
-        switchUser(...getUserIsPIHasNoMembersNoMemberRequests());
-        $pi = $USER;
-        $piGroup = $USER->getPIGroup();
-        $this->assertTrue($piGroup->exists());
+        http_post(
+            __DIR__ . "/../../webroot/panel/groups.php",
+            ["form_type" => "addPIform", "pi" => $gid]
+        );
+    }
+
+    private function assertGroupMembers(UnityGroup $group, array $members)
+    {
         $this->assertTrue(
             arraysAreEqualUnOrdered(
-                [$pi->getUID()],
-                $piGroup->getGroupMemberUIDs()
+                $members,
+                $group->getGroupMemberUIDs()
             )
         );
+    }
+
+    public function testApproveRequest()
+    {
+        global $USER;
+        $userSwitchArgs = getNormalUser();
+        $piSwitchArgs = getUserIsPIHasNoMembersNoMemberRequests();
+        switchUser(...$userSwitchArgs);
+        $user = $USER;
+        $uid = $USER->getUID();
+        switchUser(...$piSwitchArgs);
+        $piUID = $USER->getUID();
+        $piGroup = $USER->getPIGroup();
+
+        $this->assertTrue($piGroup->exists());
+        $this->assertGroupMembers($piGroup, [$piUID]);
         $this->assertEmpty($piGroup->getRequests());
-        $requestedUser = new UnityUser(self::$requestUid, $LDAP, $SQL, $MAILER, $REDIS, $WEBHOOK);
         try {
-            $piGroup->newUserRequest($requestedUser);
-            $this->assertFalse($piGroup->userExists($requestedUser));
+            switchUser(...$userSwitchArgs);
+            $this->requestJoinPI($piGroup->getPIUID());
+            $this->assertFalse($piGroup->userExists($user));
 
-            $piGroup->approveUser($requestedUser);
+            switchUser(...$piSwitchArgs);
+            $this->approveUser($uid);
             $this->assertEmpty($piGroup->getRequests());
-
-            $this->assertTrue(
-                arraysAreEqualUnOrdered(
-                    [$pi->getUID(), self::$requestUid],
-                    $piGroup->getGroupMemberUIDs()
-                )
-            );
-            $this->assertTrue($piGroup->userExists($requestedUser));
+            $this->assertGroupMembers($piGroup, [$piUID, $uid]);
+            $this->assertTrue($piGroup->userExists($user));
         } finally {
-            $piGroup->removeUser($requestedUser);
-            $SQL->removeRequest(self::$requestUid, $piGroup->getPIUID());
+            if ($piGroup->userExists($user)) {
+                $piGroup->removeUser($user);
+            }
+            if ($piGroup->requestExists($user)) {
+                $piGroup->cancelGroupJoinRequest($user);
+            }
         }
     }
 
     public function testApproveNonexistentRequest()
     {
-        global $USER, $LDAP, $SQL, $MAILER, $REDIS, $WEBHOOK;
+        global $USER;
+        switchUser(...getNormalUser2());
+        $user = $USER;
+        $uid = $USER->getUID();
         switchUser(...getUserIsPIHasNoMembersNoMemberRequests());
-        $pi = $USER;
+        $piUID = $USER->getUID();
         $piGroup = $USER->getPIGroup();
+
         $this->assertTrue($piGroup->exists());
-        $this->assertTrue(
-            arraysAreEqualUnOrdered(
-                [$pi->getUID()],
-                $piGroup->getGroupMemberUIDs()
-            )
-        );
+        $this->assertGroupMembers($piGroup, [$piUID]);
         $this->assertEmpty($piGroup->getRequests());
-
-        $notRequestedUser = new UnityUser(self::$noRequestUid, $LDAP, $SQL, $MAILER, $REDIS, $WEBHOOK);
-        $this->assertFalse($piGroup->userExists($notRequestedUser));
+        $this->assertFalse($piGroup->userExists($user));
         $this->assertEmpty($piGroup->getRequests());
-
         try {
             $this->expectException(Exception::class);
-            $piGroup->approveUser($notRequestedUser);
+            $piGroup->approveUser($user);
         } finally {
-            if ($piGroup->userExists($notRequestedUser)) {
-                $piGroup->removeUser($notRequestedUser);
+            if ($piGroup->userExists($user)) {
+                $piGroup->removeUser($user);
             }
         }
     }

--- a/test/functional/PiMemberDenyTest.php
+++ b/test/functional/PiMemberDenyTest.php
@@ -37,7 +37,13 @@ class PiMemberDenyTest extends TestCase {
         $this->assertEmpty($piGroup->getRequests());
         $requestedUser = new UnityUser(self::$requestUid, $LDAP, $SQL, $MAILER, $REDIS, $WEBHOOK);
         try {
-            $piGroup->newUserRequest($requestedUser);
+            $piGroup->newUserRequest(
+                $requestedUser,
+                $requestedUser->getFirstname(),
+                $requestedUser->getLastname(),
+                $requestedUser->getMail(),
+                $requestedUser->getOrg(),
+            );
             $this->assertFalse($piGroup->userExists($requestedUser));
 
             $piGroup->denyUser($requestedUser);

--- a/test/functional/PiRemoveUserTest.php
+++ b/test/functional/PiRemoveUserTest.php
@@ -43,7 +43,13 @@ class PiRemoveUserTest extends TestCase {
             $this->assertFalse($piGroup->userExists($memberToDelete));
         } finally {
             if (!$piGroup->userExists($memberToDelete)) {
-                $piGroup->newUserRequest($memberToDelete);
+                $piGroup->newUserRequest(
+                    $memberToDelete,
+                    $memberToDelete->getFirstname(),
+                    $memberToDelete->getLastname(),
+                    $memberToDelete->getMail(),
+                    $memberToDelete->getOrg(),
+                );
                 $piGroup->approveUser($memberToDelete);
             }
         }
@@ -63,7 +69,13 @@ class PiRemoveUserTest extends TestCase {
             $this->assertTrue($piGroup->userExists($pi));
         } finally {
             if (!$piGroup->userExists($pi)) {
-                $piGroup->newUserRequest($pi);
+                $piGroup->newUserRequest(
+                    $pi,
+                    $pi->getFirstname(),
+                    $pi->getLastname(),
+                    $pi->getMail(),
+                    $pi->getOrg(),
+                );
                 $piGroup->approveUser($pi);
             }
        }

--- a/tools/docker-dev/build.sh
+++ b/tools/docker-dev/build.sh
@@ -3,4 +3,4 @@ set -e
 cd "$(dirname "$0")"
 docker-compose down
 docker-compose build
-docker image prune
+# docker image prune

--- a/tools/docker-dev/sql/bootstrap.sql
+++ b/tools/docker-dev/sql/bootstrap.sql
@@ -173,6 +173,10 @@ CREATE TABLE `requests` (
   `id` int(11) NOT NULL,
   `request_for` varchar(131) NOT NULL,
   `uid` varchar(128) NOT NULL,
+  `firstname` varchar(768) NOT NULL,
+  `lastname` varchar(768) NOT NULL,
+  `email` varchar(768) NOT NULL,
+  `org` varchar(768) NOT NULL,
   `timestamp` timestamp NOT NULL DEFAULT current_timestamp()
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 

--- a/webroot/admin/ajax/get_group_members.php
+++ b/webroot/admin/ajax/get_group_members.php
@@ -17,17 +17,17 @@ $group = new UnityGroup($_GET["pi_uid"], $LDAP, $SQL, $MAILER, $REDIS, $WEBHOOK)
 $members = $group->getGroupMembers();
 $requests = $group->getRequests();
 
-$key = 0;
+$i = 0;
 $count = count($members) + count($requests);
 foreach ($members as $member) {
     if ($member->getUID() == $group->getOwner()->getUID()) {
         continue;
     }
 
-    if ($key >= $count - 1) {
-        echo "<tr class='expanded $key last'>";
+    if ($i >= $count - 1) {
+        echo "<tr class='expanded $i last'>";
     } else {
-        echo "<tr class='expanded $key'>";
+        echo "<tr class='expanded $i'>";
     }
 
     echo "<td>" . $member->getFullname() . "</td>";
@@ -45,14 +45,14 @@ foreach ($members as $member) {
     echo "</td>";
     echo "</tr>";
 
-    $key++;
+    $i++;
 }
 
-foreach ($requests as $key => [$user, $timestamp, $firstname, $lastname, $email, $org]) {
-    if ($key >= $count - 1) {
-        echo "<tr class='expanded $key last'>";
+foreach ($requests as $i => [$user, $timestamp, $firstname, $lastname, $email, $org]) {
+    if ($i >= $count - 1) {
+        echo "<tr class='expanded $i last'>";
     } else {
-        echo "<tr class='expanded $key'>";
+        echo "<tr class='expanded $i'>";
     }
     $uid = $user->getUID();
     echo "<td>" . $firstname . " " . $lastname . "</td>";
@@ -70,5 +70,5 @@ foreach ($requests as $key => [$user, $timestamp, $firstname, $lastname, $email,
     echo "</td>";
     echo "</tr>";
 
-    $key++;
+    $i++;
 }

--- a/webroot/admin/ajax/get_group_members.php
+++ b/webroot/admin/ajax/get_group_members.php
@@ -48,23 +48,22 @@ foreach ($members as $member) {
     $key++;
 }
 
-foreach ($requests as $key => $request) {
+foreach ($requests as $key => [$user, $timestamp, $firstname, $lastname, $email, $org]) {
     if ($key >= $count - 1) {
         echo "<tr class='expanded $key last'>";
     } else {
         echo "<tr class='expanded $key'>";
     }
-
-    [$request, $timestamp] = $request;
-    echo "<td>" . $request->getFirstname() . " " . $request->getLastname() . "</td>";
-    echo "<td>" . $request->getUID() . "</td>";
-    echo "<td><a href='mailto:" . $request->getMail() . "'>" . $request->getMail() . "</a></td>";
+    $uid = $user->getUID();
+    echo "<td>" . $firstname . " " . $lastname . "</td>";
+    echo "<td>" . $uid . "</td>";
+    echo "<td><a href='mailto:" . $email . "'>" . $email . "</a></td>";
     echo "<td>";
     echo
     "<form action='' method='POST' 
-    onsubmit='return confirm(\"Are you sure you want to approve " . $request->getUID() . "?\");'>
+    onsubmit='return confirm(\"Are you sure you want to approve " . $uid . "?\");'>
     <input type='hidden' name='form_type' value='reqChild'>
-    <input type='hidden' name='uid' value='" . $request->getUID() . "'>
+    <input type='hidden' name='uid' value='" . $uid . "'>
     <input type='hidden' name='pi' value='" . $group->getPIUID() . "'>
     <input type='submit' name='action' value='Approve'>
     <input type='submit' name='action' value='Deny'></form>";

--- a/webroot/admin/pi-mgmt.php
+++ b/webroot/admin/pi-mgmt.php
@@ -77,19 +77,19 @@ include $LOC_HEADER;
         $request_user = new UnityUser($request["uid"], $LDAP, $SQL, $MAILER, $REDIS, $WEBHOOK);
 
         echo "<tr>";
-        echo "<td>" . $request_user->getFirstname() . " " . $request_user->getLastname() . "</td>";
-        echo "<td>" . $request_user->getUID() . "</td>";
-        echo "<td><a href='mailto:" . $request_user->getMail() . "'>" . $request_user->getMail() . "</a></td>";
+        echo "<td>" . $request["firstname"] . " " . $request["lastname"] . "</td>";
+        echo "<td>" . $request["uid"] . "</td>";
+        echo "<td><a href='mailto:" . $request["mail"] . "'>" . $request["mail"] . "</a></td>";
         echo "<td>" . date("jS F, Y", strtotime($request['timestamp'])) . "</td>";
         echo "<td>";
         echo
         "<form action='' method='POST'>
         <input type='hidden' name='form_type' value='req'>
-        <input type='hidden' name='uid' value='" . $request_user->getUID() . "'>
+        <input type='hidden' name='uid' value='" . $request["uid"] . "'>
         <input type='submit' name='action' value='Approve'
-        onclick='return confirm(\"Are you sure you want to approve " . $request_user->getUID() . "?\");'>
+        onclick='return confirm(\"Are you sure you want to approve " . $request["uid"] . "?\");'>
         <input type='submit' name='action' value='Deny'
-        onclick='return confirm(\"Are you sure you want to deny " . $request_user->getUID() . "?\");'>
+        onclick='return confirm(\"Are you sure you want to deny " . $request["uid"] . "?\");'>
         </form>";
         echo "</td>";
         echo "</tr>";

--- a/webroot/panel/account.php
+++ b/webroot/panel/account.php
@@ -69,7 +69,7 @@ if ($_SERVER['REQUEST_METHOD'] == "POST") {
             $USER->getPIGroup()->requestGroup(
                 $SSO["firstname"],
                 $SSO["lastname"],
-                $SSO["email"],
+                $SSO["mail"],
                 $SSO["org"],
                 $SEND_PIMESG_TO_ADMINS
             );

--- a/webroot/panel/account.php
+++ b/webroot/panel/account.php
@@ -54,11 +54,25 @@ if ($_SERVER['REQUEST_METHOD'] == "POST") {
             $USER->setLoginShell($_POST["shellSelect"], $OPERATOR);
             break;
         case "pi_request":
-            if (!$USER->isPI()) {
-                if (!$SQL->requestExists($USER->getUID())) {
-                    $USER->getPIGroup()->requestGroup($SEND_PIMESG_TO_ADMINS);
-                }
+            if ($USER->isPI()) {
+                UnitySite::badRequest("already a PI");
             }
+            if ($SQL->requestExists($USER->getUID())) {
+                UnitySite::badRequest("already requested to be PI");
+            }
+            if ($USER->getUID() != $SSO["user"]) {
+                UnitySite::badRequest(
+                    "cannot request due to uid mismatch: " .
+                        "USER='{$USER->getUID()}' SSO[user]='$sso_user'"
+                );
+            }
+            $USER->getPIGroup()->requestGroup(
+                $SSO["firstname"],
+                $SSO["lastname"],
+                $SSO["email"],
+                $SSO["org"],
+                $SEND_PIMESG_TO_ADMINS
+            );
             break;
         case "account_deletion_request":
             $hasGroups = count($USER->getGroups()) > 0;

--- a/webroot/panel/groups.php
+++ b/webroot/panel/groups.php
@@ -47,7 +47,7 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
 
                 // Add row to sql
                 if (empty($modalErrors)) {
-                    $pi_account->newUserRequest($USER, $SSO["firstname"], $SSO["lastname"], $SSO["mail"], $SSO["org "]);
+                    $pi_account->newUserRequest($USER, $SSO["firstname"], $SSO["lastname"], $SSO["mail"], $SSO["org"]);
                 }
                 break;
             case "removePIForm":

--- a/webroot/panel/groups.php
+++ b/webroot/panel/groups.php
@@ -33,15 +33,9 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
 
                 if ($USER->getUID() != $SSO["user"]) {
                     $sso_user = $SSO["user"];
-                    UnitySite::errorLog(
-                        "warning",
+                    UnitySite::badRequest(
                         "cannot request due to uid mismatch: " .
                             "USER='{$USER->getUID()}' SSO[user]='$sso_user'"
-                    );
-                    array_push(
-                        $modalErrors,
-                        "The requesting user must be the one signed in with SSO. " .
-                            "Are you an admin viewing as another user?"
                     );
                 }
 

--- a/webroot/panel/groups.php
+++ b/webroot/panel/groups.php
@@ -31,9 +31,23 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
                     array_push($modalErrors, "You\'re already in this PI group");
                 }
 
+                if ($USER->getUID() != $SSO["user"]) {
+                    $sso_user = $SSO["user"];
+                    UnitySite::errorLog(
+                        "warning",
+                        "cannot request due to uid mismatch: " .
+                            "USER='{$USER->getUID()}' SSO[user]='$sso_user'"
+                    );
+                    array_push(
+                        $modalErrors,
+                        "The requesting user must be the one signed in with SSO. " .
+                            "Are you an admin viewing as another user?"
+                    );
+                }
+
                 // Add row to sql
                 if (empty($modalErrors)) {
-                    $pi_account->newUserRequest($USER);
+                    $pi_account->newUserRequest($USER, $SSO["firstname"], $SSO["lastname"], $SSO["mail"], $SSO["org "]);
                 }
                 break;
             case "removePIForm":
@@ -160,6 +174,7 @@ if ($SQL->accDeletionRequestExists($USER->getUID())) {
     }
     ?>
 
+    // tables.js uses ajax_url to populate expandable tables
     var ajax_url = "<?php echo $CONFIG["site"]["prefix"]; ?>/panel/ajax/get_group_members.php?pi_uid=";
 </script>
 

--- a/webroot/panel/pi.php
+++ b/webroot/panel/pi.php
@@ -53,21 +53,23 @@ if (count($requests) > 0) {
     echo "<h5>Pending Requests</h5>";
     echo "<table>";
 
-    foreach ($requests as $request) {
+    foreach ($requests as [$user, $timestamp, $firstname, $lastname, $email, $org]) {
+        $uid = $user->getUID();
+        $date = date("jS F, Y", strtotime($timestamp));
         echo "<tr>";
-        echo "<td>" . $request[0]->getFirstname() . " " . $request[0]->getLastname() . "</td>";
-        echo "<td>" . $request[0]->getUID() . "</td>";
-        echo "<td><a href='mailto:" . $request[0]->getMail() . "'>" . $request[0]->getMail() . "</a></td>";
-        echo "<td>" . date("jS F, Y", strtotime($request[1])) . "</td>";
+        echo "<td>" . $firstname . " " . $lastname . "</td>";
+        echo "<td>" . $uid . "</td>";
+        echo "<td><a href='mailto:" . $email . "'>" . $email . "</a></td>";
+        echo "<td>" . $date . "</td>";
         echo "<td>";
         echo
         "<form action='' method='POST'>
         <input type='hidden' name='form_type' value='userReq'>
-        <input type='hidden' name='uid' value='" . $request[0]->getUID() . "'>
+        <input type='hidden' name='uid' value='" . $uid . "'>
         <input type='submit' name='action' value='Approve'
-        onclick='return confirm(\"Are you sure you want to approve " . $request[0]->getUID() . "?\")'>
+        onclick='return confirm(\"Are you sure you want to approve " . $uid . "?\")'>
         <input type='submit' name='action' value='Deny'
-        onclick='return confirm(\"Are you sure you want to deny " . $request[0]->getUID() . "?\")'>
+        onclick='return confirm(\"Are you sure you want to deny " . $uid . "?\")'>
         </form>";
         echo "</td>";
         echo "</tr>";


### PR DESCRIPTION
Problem:

When redis is flushed, the names/emails/orgs of all nonexistent users disappear. Any attempt to approve requests made by these users will result in a white screen of death because the portal doesn't know what name/email/org to write to LDAP.

Solution:

Any access to name/email/org for a nonexistent user is now an error. name/email/org are stored with each request.

Notes:

The request creations now have assertions that `$USER` and `$SSO` match. This is to prevent an admin from viewing as another user and accidentally submitting a request for that user with the admin's name/email/org.