### PR TITLE
Fix ldap_escape calls to correct the argument list

### DIFF
--- a/resources/lib/UnityLDAP.php
+++ b/resources/lib/UnityLDAP.php
@@ -312,25 +312,25 @@ class UnityLDAP extends ldapConn
 
     public function getUserEntry($uid)
     {
-        $uid = ldap_escape($uid, LDAP_ESCAPE_DN);
+        $uid = ldap_escape($uid, "", LDAP_ESCAPE_DN);
         return $this->getEntry(unityLDAP::RDN . "=$uid," . $this->STR_USEROU);
     }
 
     public function getGroupEntry($gid)
     {
-        $gid = ldap_escape($gid, LDAP_ESCAPE_DN);
+        $gid = ldap_escape($gid, "", LDAP_ESCAPE_DN);
         return $this->getEntry(unityLDAP::RDN . "=$gid," . $this->STR_GROUPOU);
     }
 
     public function getPIGroupEntry($gid)
     {
-        $gid = ldap_escape($gid, LDAP_ESCAPE_DN);
+        $gid = ldap_escape($gid, "", LDAP_ESCAPE_DN);
         return $this->getEntry(unityLDAP::RDN . "=$gid," . $this->STR_PIGROUPOU);
     }
 
     public function getOrgGroupEntry($gid)
     {
-        $gid = ldap_escape($gid, LDAP_ESCAPE_DN);
+        $gid = ldap_escape($gid, "", LDAP_ESCAPE_DN);
         return $this->getEntry(unityLDAP::RDN . "=$gid," . $this->STR_ORGGROUPOU);
     }
 }


### PR DESCRIPTION
Were passing the second argument as if it was the first. Added the default value for the second.