### PR TITLE
improve logging

### DIFF
--- a/defaults/config.ini.default
+++ b/defaults/config.ini.default
@@ -15,7 +15,7 @@ terms_of_service_url = "https://github.com" ; this can be external or a portal p
 account_policy_url = "https://github.com" ; this can be external or a portal page created with "content management"
 allow_die = true ; internal use only
 enable_verbose_error_log = true ; internal use only
-enable_shutdown_msg = true ; internal use only
+enable_error_to_user = true ; internal use only
 
 [ldap]
 uri = "ldap://identity"  ; URI of remote LDAP server

--- a/deployment/overrides/phpunit/config/config.ini
+++ b/deployment/overrides/phpunit/config/config.ini
@@ -4,4 +4,4 @@ custom_user_mappings_dir = "test/custom_user_mappings"
 [site]
 allow_die = false
 enable_verbose_error_log = false
-enable_shutdown_message = false
+enable_error_to_user = false

--- a/deployment/overrides/worker/config/config.ini
+++ b/deployment/overrides/worker/config/config.ini
@@ -1,2 +1,2 @@
 [site]
-enable_shutdown_msg = false
+enable_error_to_user = false


### PR DESCRIPTION
This is only a slight improvement for https://github.com/UnityHPC/unity-web-portal/issues/306. In general, I think it makes sense for "forbidden" and "bad request" errors to also make an error popup and generate an error ID.

* moved the user-facing error message functionality from the shutdown function to `UnitySite::errorToUser`
* activated user-facing error message functionality in `badRequest`, `forbidden`
* extended `UnitySite::errorLog` to take new parameters `errorid`, `error`, `data`
    * before, `errorid` was only printed from the shutdown function, and it was assumed that the reader would look at the previous message from `errorLog` to correlate it with the `errorid`
    * `data` parameter is used by the shutdown function since `error_get_last` doesn't return a `Throwable` but just an array of error info
* extended `badRequest`, `forbidden` to take new parameters `error`, `data`
    * not yet used, should prove useful
    * [`ArrayKeyException`](https://github.com/UnityHPC/unity-web-portal/pull/311) is one good use for the `error` for `badRequest`
* created `UnitySite::throwableToArray` for nice logging of thrown errors/exceptions
* removed json pretty-printing from phpopenldaper
* enabled the `JSON_UNESCAPED_SLASHES` flag
* split stack traces by newline for more readable JSON output
* replaced the `enable_shutdown_message` config option with a new `enable_error_to_user` config option
* replaced `UnitySite::headerResponseCode($code, $reason)` with `http_response_code()`

## example: uncaught exception

### before

error log:

`[Mon Sep 22 17:27:22.669519 2025] [php:notice] [pid 11] [client 192.168.65.1:26058] internal server error: {"message":"{\\"type\\":1,\\"message\\":\\"Uncaught Exception in \\\\\\/var\\\\\\/www\\\\\\/unity-web-portal\\\\\\/webroot\\\\\\/panel\\\\\\/new_account.php:72\\\\nStack trace:\\\\n#0 {main}\\\\n  thrown\\",\\"file\\":\\"\\\\\\/var\\\\\\/www\\\\\\/unity-web-portal\\\\\\/webroot\\\\\\/panel\\\\\\/new_account.php\\",\\"line\\":72,\\"unity_error_id\\":\\"68d186faa3727\\"}","REMOTE_USER":"user2001@org998.test","REMOTE_ADDR":"192.168.65.1","trace":"#0 \\/var\\/www\\/unity-web-portal\\/resources\\/lib\\/UnitySite.php(89): UnityWebPortal\\\\lib\\\\UnitySite::errorLog()\\n#1 [internal function]: UnityWebPortal\\\\lib\\\\UnitySite::shutdown()\\n#2 {main}"}, referer: http://127.0.0.1:8000/`

json reformatted:

```json
{
    "message": "{\\"type\\":1,\\"message\\":\\"Uncaught Exception in \\\\\\/var\\\\\\/www\\\\\\/unity-web-portal\\\\\\/webroot\\\\\\/panel\\\\\\/new_account.php: 72\\\\nStack trace:\\\\n#0 {main}\\\\n  thrown\\",\\"file\\":\\"\\\\\\/var\\\\\\/www\\\\\\/unity-web-portal\\\\\\/webroot\\\\\\/panel\\\\\\/new_account.php\\",\\"line\\":72,\\"unity_error_id\\":\\"68d186faa3727\\"}",
    "REMOTE_USER": "user2001@org998.test",
    "REMOTE_ADDR": "192.168.65.1",
    "trace": "#0 \\/var\\/www\\/unity-web-portal\\/resources\\/lib\\/UnitySite.php(89): UnityWebPortal\\\\lib\\\\UnitySite::errorLog()\\n#1 [internal function]: UnityWebPortal\\\\lib\\\\UnitySite::shutdown()\\n#2 {main}"
}
```

### after

error log:

`[Mon Sep 22 17:25:53.470629 2025] [php:notice] [pid 11] [client 192.168.65.1:30990] internal server error:  {"message":"An internal server error has occurred.","REMOTE_USER":"user2001@org998.test","REMOTE_ADDR":"192.168.65.1","errorid":"68d186a172e31","trace":["#0 /var/www/unity-web-portal/resources/lib/UnitySite.php(122): UnityWebPortal\\\\lib\\\\UnitySite::errorLog()","#1 /var/www/unity-web-portal/resources/lib/UnitySite.php(138): UnityWebPortal\\\\lib\\\\UnitySite::internalServerError()","#2 [internal function]: UnityWebPortal\\\\lib\\\\UnitySite::shutdown()","#3 {main}"],"data":{"error":{"type":1,"message":["Uncaught Exception in /var/www/unity-web-portal/webroot/panel/new_account.php:72","Stack trace:","#0 {main}","  thrown"],"file":"/var/www/unity-web-portal/webroot/panel/new_account.php","line":72}}}, referer: http://127.0.0.1:8000/index.php`

json reformatted:

```json
{
    "message": "An internal server error has occurred.",
    "REMOTE_USER": "user2001@org998.test",
    "REMOTE_ADDR": "192.168.65.1",
    "errorid": "68d186a172e31",
    "trace": [
        "#0 /var/www/unity-web-portal/resources/lib/UnitySite.php(122): UnityWebPortal\\\\lib\\\\UnitySite::errorLog()",
        "#1 /var/www/unity-web-portal/resources/lib/UnitySite.php(138): UnityWebPortal\\\\lib\\\\UnitySite::internalServerError()",
        "#2 [internal function]: UnityWebPortal\\\\lib\\\\UnitySite::shutdown()",
        "#3 {main}"
    ],
    "data": {
        "error": {
            "type": 1,
            "message": [
                "Uncaught Exception in /var/www/unity-web-portal/webroot/panel/new_account.php:72",
                "Stack trace:",
                "#0 {main}",
                "  thrown"
            ],
            "file": "/var/www/unity-web-portal/webroot/panel/new_account.php",
            "line": 72
        }
    }
}
```

## example: bad request

### before

error log:

`[Mon Sep 22 17:36:26.948241 2025] [php:notice] [pid 16] [client 192.168.65.1:64646] bad request: {"message":"The selected PI 'foobar'does not exist","REMOTE_USER":"user2001@org998.test","REMOTE_ADDR":"192.168.65.1","trace":"#0 \\/var\\/www\\/unity-web-portal\\/resources\\/lib\\/UnitySite.php(61): UnityWebPortal\\\\lib\\\\UnitySite::errorLog()\\n#1 \\/var\\/www\\/unity-web-portal\\/webroot\\/panel\\/new_account.php(29): UnityWebPortal\\\\lib\\\\UnitySite::badRequest()\\n#2 {main}"}, referer: http://127.0.0.1:8000/panel/new_account.php`

json reformatted:

```json
{
    "message": "The selected PI 'foobar'does not exist",
    "REMOTE_USER": "user2001@org998.test",
    "REMOTE_ADDR": "192.168.65.1",
    "trace": "#0 \\/var\\/www\\/unity-web-portal\\/resources\\/lib\\/UnitySite.php(61): UnityWebPortal\\\\lib\\\\UnitySite::errorLog()\\n#1 \\/var\\/www\\/unity-web-portal\\/webroot\\/panel\\/new_account.php(29): UnityWebPortal\\\\lib\\\\UnitySite::badRequest()\\n#2 {main}"
}
```

### after

error log:

`[Mon Sep 22 17:37:38.080828 2025] [php:notice] [pid 11] [client 192.168.65.1:42080] bad request: {"message":"The selected PI 'foobar'does not exist","REMOTE_USER":"user2001@org998.test","REMOTE_ADDR":"192.168.65.1","errorid":"68d1896213b8a","trace":["#0 /var/www/unity-web-portal/resources/lib/UnitySite.php(106): UnityWebPortal\\\\lib\\\\UnitySite::errorLog()","#1 /var/www/unity-web-portal/webroot/panel/new_account.php(29): UnityWebPortal\\\\lib\\\\UnitySite::badRequest()","#2 {main}"]}, referer: http://127.0.0.1:8000/panel/new_account.php`

json reformatted:

```json
{
    "message": "The selected PI 'foobar'does not exist",
    "REMOTE_USER": "user2001@org998.test",
    "REMOTE_ADDR": "192.168.65.1",
    "errorid": "68d1896213b8a",
    "trace": [
        "#0 /var/www/unity-web-portal/resources/lib/UnitySite.php(106): UnityWebPortal\\\\lib\\\\UnitySite::errorLog()",
        "#1 /var/www/unity-web-portal/webroot/panel/new_account.php(29): UnityWebPortal\\\\lib\\\\UnitySite::badRequest()",
        "#2 {main}"
    ]
}
```